### PR TITLE
Migrate from Leptonic to Thaw

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,6 @@ jobs:
       #with:
       #  version: 'v0.18.4'
 
-    # workaround unidentified issue with missing dir
-    - name: Stylesheet creation workaround
-      run: mkdir -p style/leptonic && test -r ./style/leptonic/leptonic-themes.scss || trunk build --verbose --release --public-url "./" || true
-
     - name: Build
       run: trunk build --verbose --release --public-url "./"
     - name: Upload artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@1.80
+    - uses: dtolnay/rust-toolchain@1.87
       with:
         targets: wasm32-unknown-unknown
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /target/
 /dist/
-/style/leptonic/
 /data/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,8 +1752,7 @@ dependencies = [
 [[package]]
 name = "thaw"
 version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2ea14de27ddd0ce167c69e78852122c5a9c755b3c083c8249e491c4a8821ce"
+source = "git+https://github.com/thaw-ui/thaw?branch=thaw-v0.3#23230a6d65a45e56c6bb4e52a34f6e217d4ba55c"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -1772,8 +1771,7 @@ dependencies = [
 [[package]]
 name = "thaw_components"
 version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ee9d9598f7a5162845a83ef0ed3ccde52c23d987cf64433056b2fd4542161c"
+source = "git+https://github.com/thaw-ui/thaw?branch=thaw-v0.3#23230a6d65a45e56c6bb4e52a34f6e217d4ba55c"
 dependencies = [
  "cfg-if",
  "leptos",
@@ -1785,8 +1783,7 @@ dependencies = [
 [[package]]
 name = "thaw_utils"
 version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d5fe5c99ba6b6730ec533810dd4d92422b778d4fbaffa9b6d7fb705b28b3978"
+source = "git+https://github.com/thaw-ui/thaw?branch=thaw-v0.3#23230a6d65a45e56c6bb4e52a34f6e217d4ba55c"
 dependencies = [
  "cfg-if",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,15 +33,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9747eb01aed7603aba23f7c869d5d7e5d37aab9c3501aced42d8fdb786f1f6e3"
 dependencies = [
  "futures",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "approx"
@@ -107,15 +107,15 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "by_address"
@@ -125,9 +125,9 @@ checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "camino"
@@ -137,9 +137,9 @@ checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 
 [[package]]
 name = "cc"
-version = "1.2.0"
+version = "1.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aeb932158bd710538c73702db6945cb68a8fb08c519e6e12706b94263b36db8"
+checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
 dependencies = [
  "shlex",
 ]
@@ -152,16 +152,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -172,7 +172,7 @@ checksum = "5d3ad3122b0001c7f140cf4d605ef9a9e2c24d96ab0b4fb4347b76de2425f445"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -215,18 +215,18 @@ dependencies = [
 
 [[package]]
 name = "const_format"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
 dependencies = [
  "const_format_proc_macros",
 ]
 
 [[package]]
 name = "const_format_proc_macros"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -256,9 +256,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "dashmap"
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "derive-where"
-version = "1.2.7"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
+checksum = "e73f2692d4bd3cac41dca28934a39894200c9fabf49586d77d0e5954af1d7902"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -304,30 +304,31 @@ checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "either_of"
-version = "0.1.0"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e22feb4d5cacf9f2c64902a1c35ef0f2d766e42db316a98b93992bbce669cb"
+checksum = "216d23e0ec69759a17f05e1c553f3a6870e5ec73420fbb07807a6f34d5d1d5a4"
 dependencies = [
+ "paste",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "event-listener"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -336,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
@@ -482,21 +483,21 @@ dependencies = [
  "server_fn_macro_default",
  "tachys",
  "thaw",
+ "thaw_macro",
  "throw_error",
  "web-sys",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
+ "r-efi",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -514,7 +515,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -535,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "guardian"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "493913a18c0d7bebb75127a26a432162c59edbe06f6cf712001e3e769345e8b5"
+checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
 
 [[package]]
 name = "hashbrown"
@@ -547,9 +548,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "html-escape"
@@ -562,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -587,14 +588,15 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -644,21 +646,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -668,30 +671,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -699,65 +682,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -773,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -802,12 +772,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -827,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
@@ -867,7 +837,7 @@ dependencies = [
  "server_fn",
  "slotmap",
  "tachys",
- "thiserror",
+ "thiserror 1.0.69",
  "throw_error",
  "typed-builder",
  "typed-builder-macro",
@@ -884,7 +854,7 @@ dependencies = [
  "config",
  "regex",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "typed-builder",
 ]
 
@@ -977,7 +947,7 @@ dependencies = [
  "reactive_graph",
  "send_wrapper",
  "tachys",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
  "wasm-bindgen",
  "web-sys",
@@ -1016,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.162"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "linear-map"
@@ -1028,9 +998,9 @@ checksum = "bfae20f6b19ad527b550c223fddc3077a547fc70cda94b9b566575423fd303ee"
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -1044,9 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "manyhow"
@@ -1115,14 +1085,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64b94982fe39a861561cf67ff17a7849f2cedadbbad960a797634032b7abb998"
 dependencies = [
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "opr"
@@ -1148,6 +1118,15 @@ name = "or_poisoned"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c04f5d74368e4d0dfe06c45c8627c81bd7c317d52762d118fb9b3076f6420fd"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "palette"
@@ -1210,9 +1189,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c5ce1153ab5b689d0c074c4e7fc613e942dfb7dd9eea5ab202d2ad91fe361"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -1222,9 +1201,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "phf"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -1232,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
  "rand",
@@ -1242,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -1255,27 +1234,27 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.7"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.7"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1284,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -1295,36 +1274,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.25"
+name = "potential_utf"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
  "syn",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -1373,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -1395,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -1423,6 +1388,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
@@ -1456,7 +1427,7 @@ dependencies = [
  "send_wrapper",
  "serde",
  "slotmap",
- "thiserror",
+ "thiserror 1.0.69",
  "web-sys",
 ]
 
@@ -1490,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags",
 ]
@@ -1528,9 +1499,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rstml"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51187e564f12336ef40cd04f6f4d805d6919188001dcf1e0a021898ea0fe28ce"
+checksum = "61cf4616de7499fc5164570d40ca4e1b24d231c6833a88bff0fe00725080fd56"
 dependencies = [
  "derive-where",
  "proc-macro2",
@@ -1538,20 +1509,20 @@ dependencies = [
  "quote",
  "syn",
  "syn_derive",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -1579,28 +1550,39 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde-aux"
-version = "4.5.0"
+version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d2e8bfba469d06512e11e3311d4d051a4a387a5b42d010404fecf3200321c95"
+checksum = "207f67b28fe90fb596503a9bf0bf1ea5e831e21307658e177c5dfcdfc3ab8a0a"
 dependencies = [
  "serde",
+ "serde-value",
  "serde_json",
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.215"
+name = "serde-value"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1609,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -1627,7 +1609,7 @@ checksum = "cd34f36fe4c5ba9654417139a9b3a20d2e1de6012ee678ad14d240c22c78d8d6"
 dependencies = [
  "percent-encoding",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1659,7 +1641,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "server_fn_macro_default",
- "thiserror",
+ "thiserror 1.0.69",
  "throw_error",
  "url",
  "wasm-bindgen",
@@ -1701,9 +1683,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -1725,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1737,9 +1719,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1748,11 +1730,11 @@ dependencies = [
 
 [[package]]
 name = "syn_derive"
-version = "0.1.8"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
+checksum = "cdb066a04799e45f5d582e8fc6ec8e6d6896040d00898eb4e6a835196815b219"
 dependencies = [
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn",
@@ -1760,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1869,7 +1851,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1877,6 +1868,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1894,9 +1896,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1904,9 +1906,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1916,25 +1918,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "typed-builder"
@@ -1958,9 +1967,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1976,20 +1985,14 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
 ]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8-width"
@@ -2005,11 +2008,12 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom",
+ "js-sys",
  "wasm-bindgen",
 ]
 
@@ -2031,9 +2035,12 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2136,11 +2143,61 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-targets",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2218,30 +2275,33 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
+name = "wit-bindgen-rt"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.12"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yansi"
@@ -2251,9 +2311,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -2263,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2275,18 +2335,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2295,10 +2355,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2307,9 +2378,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "async-recursion"
@@ -83,6 +107,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytes"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,13 +125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 
 [[package]]
-name = "cargo_toml"
-version = "0.19.2"
+name = "cc"
+version = "1.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98356df42a2eb1bd8f1793ae4ee4de48e384dd974ce5eac8eee802edb7492be"
+checksum = "baee610e9452a8f6f0a1b6194ec09ff9e2d85dea54432acdae41aa0761c95d70"
 dependencies = [
- "serde",
- "toml",
+ "shlex",
 ]
 
 [[package]]
@@ -109,6 +138,20 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets",
+]
 
 [[package]]
 name = "ciborium"
@@ -135,15 +178,6 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
-]
-
-[[package]]
-name = "codee"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d3ad3122b0001c7f140cf4d605ef9a9e2c24d96ab0b4fb4347b76de2425f445"
-dependencies = [
- "thiserror",
 ]
 
 [[package]]
@@ -205,56 +239,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "cookie"
-version = "0.18.1"
+name = "core-foundation-sys"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
-name = "darling"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "dashmap"
@@ -267,28 +261,6 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
-]
-
-[[package]]
-name = "default-struct-builder"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0df63c21a4383f94bd5388564829423f35c316aed85dc4f8427aded372c7c0d"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "deranged"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
-dependencies = [
- "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -330,6 +302,12 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fnv"
@@ -442,7 +420,6 @@ dependencies = [
  "cfg-if",
  "console_error_panic_hook",
  "gloo-net 0.5.0",
- "leptonic",
  "leptos",
  "leptos_macro",
  "leptos_meta",
@@ -450,6 +427,7 @@ dependencies = [
  "opr",
  "opr-test-data",
  "serde",
+ "thaw",
  "web-sys",
 ]
 
@@ -509,18 +487,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "gloo-utils"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,12 +522,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 
 [[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
 name = "html-escape"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,30 +553,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "icondata"
-version = "0.3.1"
+name = "iana-time-zone"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e75326892b8f4aa213dae3fef9214b9bb5a865a5267ac2143393b72cd78ffa"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
- "icondata_ai",
- "icondata_bi",
- "icondata_bs",
- "icondata_cg",
- "icondata_ch",
- "icondata_core",
- "icondata_fa",
- "icondata_fi",
- "icondata_hi",
- "icondata_im",
- "icondata_io",
- "icondata_lu",
- "icondata_oc",
- "icondata_ri",
- "icondata_si",
- "icondata_tb",
- "icondata_ti",
- "icondata_vs",
- "icondata_wi",
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -629,163 +585,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icondata_bi"
-version = "0.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ce125f0d203e66444b02982af9b15631f2385573ad7992af79d4d4babc638d"
-dependencies = [
- "icondata_core",
-]
-
-[[package]]
-name = "icondata_bs"
-version = "0.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67940e592b0b8df8d7adc055c8542d135ce1d7d6ad01d8fb8de9405ebfc21c2e"
-dependencies = [
- "icondata_core",
-]
-
-[[package]]
-name = "icondata_cg"
-version = "0.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0eba691ca17a43ffc8ebbcf200cd3ea54ad75837f210a6a6ace87a491be8314"
-dependencies = [
- "icondata_core",
-]
-
-[[package]]
-name = "icondata_ch"
-version = "0.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2870b3c4ebf013b7e27af71d4c55f10b97ea448831e9a156cb53fec0f262dc20"
-dependencies = [
- "icondata_core",
-]
-
-[[package]]
 name = "icondata_core"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c97be924215abd5e630d84e95a47c710138a6559b4c55039f4f33aa897fa859"
-
-[[package]]
-name = "icondata_fa"
-version = "0.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7fee576096efe5567a7216a6fb8154db8eae9ae108e5a4706805204208c2af"
-dependencies = [
- "icondata_core",
-]
-
-[[package]]
-name = "icondata_fi"
-version = "0.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a4e81557c205a12ac051046595bb616f388537468987f7ee8960f897cdc538"
-dependencies = [
- "icondata_core",
-]
-
-[[package]]
-name = "icondata_hi"
-version = "0.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3435d50de04c61799613995e753e613dc4f2771aa08eb94a7318289a5ea9d784"
-dependencies = [
- "icondata_core",
-]
-
-[[package]]
-name = "icondata_im"
-version = "0.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce4bd1d64bb67bb080f605e3e600271894b67c4aaa18965179586ef5990a2297"
-dependencies = [
- "icondata_core",
-]
-
-[[package]]
-name = "icondata_io"
-version = "0.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35b9d681c936a6e087940beb4766159cddc080d7f1fd5ef0ef3ab9f50a11f3f6"
-dependencies = [
- "icondata_core",
-]
-
-[[package]]
-name = "icondata_lu"
-version = "0.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d552c45cc3ab1d1bf88cc0201004eb92418141e5454e9e0e46c4b4a4faf66248"
-dependencies = [
- "icondata_core",
-]
-
-[[package]]
-name = "icondata_oc"
-version = "0.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be19499912a05d5db89ccb88dbe3c459ca4100bda3dbcbddff69f2dcf71d305"
-dependencies = [
- "icondata_core",
-]
-
-[[package]]
-name = "icondata_ri"
-version = "0.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114a85cc95d1bfaee8dc5bf8a07dd043fc9e75499dc2ff4ac5e066193c594930"
-dependencies = [
- "icondata_core",
-]
-
-[[package]]
-name = "icondata_si"
-version = "0.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc30cb2dbc2ac53f23dddbcb0ad73720970b24c0ed13935df8082b74fb627860"
-dependencies = [
- "icondata_core",
-]
-
-[[package]]
-name = "icondata_tb"
-version = "0.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f2b8d8e2047546285805795e6d3cb6e820a52bb008e15942e11353c7ba659f2"
-dependencies = [
- "icondata_core",
-]
-
-[[package]]
-name = "icondata_ti"
-version = "0.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f85074d4bf10960d0f2b01ce3d9cfa2b2434a170d0738336411bb61e83227e4"
-dependencies = [
- "icondata_core",
-]
-
-[[package]]
-name = "icondata_vs"
-version = "0.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82bb4a8b1523200fc7c3b588bb80858db16708067093110ee8614db63b8913"
-dependencies = [
- "icondata_core",
-]
-
-[[package]]
-name = "icondata_wi"
-version = "0.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d2c65b534aa9d7ccb107d892200e8fef2d1849acad160af067e9e20ced3619b"
-dependencies = [
- "icondata_core",
-]
 
 [[package]]
 name = "icu_collections"
@@ -906,12 +709,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,12 +757,6 @@ dependencies = [
  "equivalent",
  "hashbrown 0.15.1",
 ]
-
-[[package]]
-name = "indoc"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "interpolator"
@@ -1019,47 +810,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leptonic"
-version = "0.5.0"
-source = "git+https://github.com/ydirson/leptonic/?branch=leptonic-0.5#b36b531b490cd8cc6f055e3002832479edd7fb25"
-dependencies = [
- "anyhow",
- "cargo_toml",
- "cfg-if",
- "icondata",
- "indexmap",
- "indoc",
- "itertools 0.12.1",
- "js-sys",
- "lazy_static",
- "leptonic-theme",
- "leptos",
- "leptos-use",
- "leptos_meta",
- "leptos_router",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
- "strum",
- "time",
- "tracing",
- "uuid",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "leptonic-theme"
-version = "0.5.0"
-source = "git+https://github.com/ydirson/leptonic/?branch=leptonic-0.5#b36b531b490cd8cc6f055e3002832479edd7fb25"
-dependencies = [
- "anyhow",
- "include_dir",
- "indoc",
-]
-
-[[package]]
 name = "leptos"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,30 +826,6 @@ dependencies = [
  "typed-builder",
  "typed-builder-macro",
  "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "leptos-use"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17a16cc63083779fe1081dd714b99a856e46d5ce427e7ce94300b0199a3ccb12"
-dependencies = [
- "cfg-if",
- "codee",
- "cookie",
- "default-struct-builder",
- "futures-util",
- "gloo-timers",
- "js-sys",
- "lazy_static",
- "leptos",
- "num",
- "paste",
- "thiserror",
- "unic-langid",
- "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
 ]
 
@@ -1354,76 +1080,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,6 +1130,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56d80efc4b6721e8be2a10a5df21a30fa0b470f1539e53d8b4e6e75faf938b63"
 
 [[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "palette_derive",
+ "phf",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,6 +1195,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,12 +1267,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -1682,6 +1398,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,12 +1469,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustversion"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "ryu"
@@ -1928,6 +1653,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,34 +1694,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
 
 [[package]]
 name = "syn"
@@ -2021,6 +1730,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "thaw"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2ea14de27ddd0ce167c69e78852122c5a9c755b3c083c8249e491c4a8821ce"
+dependencies = [
+ "cfg-if",
+ "chrono",
+ "icondata_ai",
+ "icondata_core",
+ "leptos",
+ "num-traits",
+ "palette",
+ "thaw_components",
+ "thaw_utils",
+ "uuid",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "thaw_components"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ee9d9598f7a5162845a83ef0ed3ccde52c23d987cf64433056b2fd4542161c"
+dependencies = [
+ "cfg-if",
+ "leptos",
+ "thaw_utils",
+ "uuid",
+ "web-sys",
+]
+
+[[package]]
+name = "thaw_utils"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5fe5c99ba6b6730ec533810dd4d92422b778d4fbaffa9b6d7fb705b28b3978"
+dependencies = [
+ "cfg-if",
+ "chrono",
+ "leptos",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2038,38 +1793,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "time"
-version = "0.3.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
-dependencies = [
- "deranged",
- "itoa",
- "js-sys",
- "num-conv",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
-
-[[package]]
-name = "time-macros"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
-dependencies = [
- "num-conv",
- "time-core",
 ]
 
 [[package]]
@@ -2168,24 +1891,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unic-langid"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dd9d1e72a73b25e07123a80776aae3e7b0ec461ef94f9151eed6ec88005a44"
-dependencies = [
- "unic-langid-impl",
-]
-
-[[package]]
-name = "unic-langid-impl"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5422c1f65949306c99240b81de9f3f15929f5a8bfe05bb44b034cc8bf593e5"
-dependencies = [
- "tinystr",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,8 +1944,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom",
- "serde",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2362,6 +2065,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,8 @@ dependencies = [
 [[package]]
 name = "any_spawner"
 version = "0.1.1"
-source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9747eb01aed7603aba23f7c869d5d7e5d37aab9c3501aced42d8fdb786f1f6e3"
 dependencies = [
  "futures",
  "thiserror",
@@ -235,7 +236,8 @@ dependencies = [
 [[package]]
 name = "const_str_slice_concat"
 version = "0.1.0"
-source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67855af358fcb20fac58f9d714c94e2b228fe5694c1c9b4ead4a366343eda1b"
 
 [[package]]
 name = "convert_case"
@@ -309,7 +311,8 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 [[package]]
 name = "either_of"
 version = "0.1.0"
-source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6e22feb4d5cacf9f2c64902a1c35ef0f2d766e42db316a98b93992bbce669cb"
 dependencies = [
  "pin-project-lite",
 ]
@@ -460,13 +463,25 @@ dependencies = [
  "gloo-net",
  "icondata",
  "leptos",
+ "leptos_config",
+ "leptos_dom",
+ "leptos_hot_reload",
  "leptos_macro",
  "leptos_meta",
  "leptos_router",
+ "leptos_router_macro",
+ "leptos_server",
+ "next_tuple",
  "opr",
  "opr-test-data",
+ "reactive_graph",
  "serde",
+ "server_fn",
+ "server_fn_macro",
+ "server_fn_macro_default",
+ "tachys",
  "thaw",
+ "throw_error",
  "web-sys",
 ]
 
@@ -557,8 +572,9 @@ dependencies = [
 
 [[package]]
 name = "hydration_context"
-version = "0.2.0-beta5"
-source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+version = "0.2.0-gamma2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da327cef06c53244d33f7c0d202f26693d787290905a5b2677a508768b1194c0"
 dependencies = [
  "futures",
  "once_cell",
@@ -825,8 +841,9 @@ dependencies = [
 
 [[package]]
 name = "leptos"
-version = "0.7.0-beta5"
-source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+version = "0.7.0-gamma2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8364ee9e0d24df4223e05dd52f56acdf2f7839e4bdada4480418e69cb4e0c831"
 dependencies = [
  "any_spawner",
  "cfg-if",
@@ -859,8 +876,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_config"
-version = "0.7.0-beta5"
-source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+version = "0.7.0-gamma2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e84d5323ef20c99e407ba1a80f44c39820fc3e9a025e0fe430858b1a62b9acc0"
 dependencies = [
  "config",
  "regex",
@@ -871,8 +889,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_dom"
-version = "0.7.0-beta5"
-source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+version = "0.7.0-gamma2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a46b55654b156018f8729770ab51162e530f1a7e5e7eae43deb4d8d78eb58"
 dependencies = [
  "js-sys",
  "or_poisoned",
@@ -885,8 +904,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_hot_reload"
-version = "0.7.0-beta5"
-source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+version = "0.7.0-gamma2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378d042feaf5eb03652bd8e5c01420afd50df1081251f84f29733dde5de223fe"
 dependencies = [
  "anyhow",
  "camino",
@@ -902,8 +922,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_macro"
-version = "0.7.0-beta5"
-source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+version = "0.7.0-gamma2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921cf1b8fc4aa10001083664492d68f7f60420c40f545a5fa5f974d8482099a8"
 dependencies = [
  "attribute-derive",
  "cfg-if",
@@ -923,8 +944,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_meta"
-version = "0.7.0-beta5"
-source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+version = "0.7.0-gamma2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a1b999b1574abc17a07a68b54fb1f7aa670c50a60c0407b05fa26fdd4108458"
 dependencies = [
  "futures",
  "indexmap",
@@ -938,8 +960,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_router"
-version = "0.7.0-beta5"
-source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+version = "0.7.0-gamma2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91a752fbf7aeaf68f56ec0eb59bda4f18293194268e16dd7ef8cf5e5b6356675"
 dependencies = [
  "any_spawner",
  "either_of",
@@ -963,24 +986,27 @@ dependencies = [
 
 [[package]]
 name = "leptos_router_macro"
-version = "0.7.0-beta5"
-source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+version = "0.7.0-gamma2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fc19f60e3687eb69ee7ea66cbf2f4032dcf473d6e56d340acff4eeb23c0a305"
 dependencies = [
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
 ]
 
 [[package]]
 name = "leptos_server"
-version = "0.7.0-beta5"
-source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+version = "0.7.0-gamma2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c981b0748be2de45ed7af9d7a0752bf8ec505b15f96e84bf88ca239857c585d"
 dependencies = [
  "any_spawner",
  "base64",
  "codee",
  "futures",
  "hydration_context",
+ "or_poisoned",
  "reactive_graph",
  "send_wrapper",
  "serde",
@@ -1060,8 +1086,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "next_tuple"
-version = "0.1.0-beta5"
-source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+version = "0.1.0-gamma2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "550cf708f0dd373c47d2d6092fc3c38826147afa57cf2f646ed7306b6b2a7f62"
 
 [[package]]
 name = "nom"
@@ -1085,7 +1112,8 @@ dependencies = [
 [[package]]
 name = "oco_ref"
 version = "0.2.0"
-source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64b94982fe39a861561cf67ff17a7849f2cedadbbad960a797634032b7abb998"
 dependencies = [
  "serde",
  "thiserror",
@@ -1119,7 +1147,8 @@ dependencies = [
 [[package]]
 name = "or_poisoned"
 version = "0.1.0"
-source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c04f5d74368e4d0dfe06c45c8627c81bd7c317d52762d118fb9b3076f6420fd"
 
 [[package]]
 name = "palette"
@@ -1412,8 +1441,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "reactive_graph"
-version = "0.1.0-beta5"
-source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+version = "0.1.0-gamma2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1278052e7c424405b17998339afb2959d97f4825f25d6f299bbb4c99dab747f"
 dependencies = [
  "any_spawner",
  "async-lock",
@@ -1583,8 +1613,9 @@ dependencies = [
 
 [[package]]
 name = "server_fn"
-version = "0.7.0-beta5"
-source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+version = "0.7.0-gamma2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a98570188735ac32205912d3460d7e12cfcf969bcd7d2b01c4c4f795711e3e"
 dependencies = [
  "bytes",
  "const_format",
@@ -1612,8 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro"
-version = "0.7.0-beta5"
-source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+version = "0.7.0-gamma2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119cea4124c6acbd0c629716264908ac6970177a34b2a9bc0e1a75c2cebdbe37"
 dependencies = [
  "const_format",
  "convert_case",
@@ -1625,8 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro_default"
-version = "0.7.0-beta5"
-source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+version = "0.7.0-gamma2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa3b8af6a3f1ed342e245c22d493f17d63c08eb597bc4e9a0ce7dda125de6ca"
 dependencies = [
  "server_fn_macro",
  "syn",
@@ -1710,8 +1743,9 @@ dependencies = [
 
 [[package]]
 name = "tachys"
-version = "0.1.0-beta5"
-source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+version = "0.1.0-gamma2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86db1124f46d9cc82beecac6448135cc2245e0edd5b533cac5ccfd5f8cf22e4c"
 dependencies = [
  "any_spawner",
  "const_str_slice_concat",
@@ -1741,7 +1775,7 @@ dependencies = [
 [[package]]
 name = "thaw"
 version = "0.4.0-beta3"
-source = "git+https://github.com/thaw-ui/thaw?rev=dfd5ddd328f2886260069bce9b8150d2307967e8#dfd5ddd328f2886260069bce9b8150d2307967e8"
+source = "git+https://github.com/thaw-ui/thaw?rev=0c5cb880950ff2229ab2762bfa64a900b70a857d#0c5cb880950ff2229ab2762bfa64a900b70a857d"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -1763,7 +1797,7 @@ dependencies = [
 [[package]]
 name = "thaw_components"
 version = "0.2.0-beta3"
-source = "git+https://github.com/thaw-ui/thaw?rev=dfd5ddd328f2886260069bce9b8150d2307967e8#dfd5ddd328f2886260069bce9b8150d2307967e8"
+source = "git+https://github.com/thaw-ui/thaw?rev=0c5cb880950ff2229ab2762bfa64a900b70a857d#0c5cb880950ff2229ab2762bfa64a900b70a857d"
 dependencies = [
  "cfg-if",
  "leptos",
@@ -1776,7 +1810,7 @@ dependencies = [
 [[package]]
 name = "thaw_macro"
 version = "0.1.0-beta3"
-source = "git+https://github.com/thaw-ui/thaw?rev=dfd5ddd328f2886260069bce9b8150d2307967e8#dfd5ddd328f2886260069bce9b8150d2307967e8"
+source = "git+https://github.com/thaw-ui/thaw?rev=0c5cb880950ff2229ab2762bfa64a900b70a857d#0c5cb880950ff2229ab2762bfa64a900b70a857d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1786,7 +1820,7 @@ dependencies = [
 [[package]]
 name = "thaw_utils"
 version = "0.1.0-beta3"
-source = "git+https://github.com/thaw-ui/thaw?rev=dfd5ddd328f2886260069bce9b8150d2307967e8#dfd5ddd328f2886260069bce9b8150d2307967e8"
+source = "git+https://github.com/thaw-ui/thaw?rev=0c5cb880950ff2229ab2762bfa64a900b70a857d#0c5cb880950ff2229ab2762bfa64a900b70a857d"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -1818,8 +1852,9 @@ dependencies = [
 
 [[package]]
 name = "throw_error"
-version = "0.2.0-beta5"
-source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+version = "0.2.0-gamma2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4fd77a12226ed7f596d9b32d52c4cdaf82b9bbb99900e4479ff4b5614d26949"
 dependencies = [
  "pin-project-lite",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,7 @@ dependencies = [
  "cfg-if",
  "console_error_panic_hook",
  "gloo-net 0.5.0",
+ "icondata",
  "leptos",
  "leptos_macro",
  "leptos_meta",
@@ -576,6 +577,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "icondata"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18db9eec46b6c870bf84281dd8065fb207b23a9c1c0cb367c49a919a61a38dec"
+dependencies = [
+ "icondata_core",
+ "icondata_io",
+]
+
+[[package]]
 name = "icondata_ai"
 version = "0.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +600,15 @@ name = "icondata_core"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c97be924215abd5e630d84e95a47c710138a6559b4c55039f4f33aa897fa859"
+
+[[package]]
+name = "icondata_io"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b9d681c936a6e087940beb4766159cddc080d7f1fd5ef0ef3ab9f50a11f3f6"
+dependencies = [
+ "icondata_core",
+]
 
 [[package]]
 name = "icu_collections"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,12 +28,12 @@ dependencies = [
 
 [[package]]
 name = "any_spawner"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9747eb01aed7603aba23f7c869d5d7e5d37aab9c3501aced42d8fdb786f1f6e3"
+checksum = "41058deaa38c9d9dd933d6d238d825227cffa668e2839b52879f6619c63eee3b"
 dependencies = [
  "futures",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "wasm-bindgen-futures",
 ]
 
@@ -64,10 +64,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "attribute-derive"
-version = "0.9.2"
+name = "async-trait"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f1ee502851995027b06f99f5ffbeffa1406b38d0b318a1ebfa469332c6cbafd"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "attribute-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0053e96dd3bec5b4879c23a138d6ef26f2cb936c9cdc96274ac2b9ed44b5bb54"
 dependencies = [
  "attribute-derive-macro",
  "derive-where",
@@ -79,14 +90,14 @@ dependencies = [
 
 [[package]]
 name = "attribute-derive-macro"
-version = "0.9.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3601467f634cfe36c4780ca9c75dea9a5b34529c1f2810676a337e7e0997f954"
+checksum = "463b53ad0fd5b460af4b1915fe045ff4d946d025fb6c4dc3337752eaa980f71b"
 dependencies = [
  "collection_literals",
  "interpolator",
  "manyhow",
- "proc-macro-utils 0.8.0",
+ "proc-macro-utils",
  "proc-macro2",
  "quote",
  "quote-use",
@@ -166,13 +177,13 @@ dependencies = [
 
 [[package]]
 name = "codee"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d3ad3122b0001c7f140cf4d605ef9a9e2c24d96ab0b4fb4347b76de2425f445"
+checksum = "0f18d705321923b1a9358e3fc3c57c3b50171196827fc7f5f10b053242aca627"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -192,15 +203,15 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.14.1"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68578f196d2a33ff61b27fae256c3164f65e36382648e30666dde05b8cc9dfdf"
+checksum = "595aae20e65c3be792d05818e8c63025294ac3cb7e200f11459063a352a6ef80"
 dependencies = [
- "convert_case",
- "nom",
+ "convert_case 0.6.0",
  "pathdiff",
  "serde",
  "toml",
+ "winnow",
 ]
 
 [[package]]
@@ -244,6 +255,15 @@ name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -301,6 +321,12 @@ name = "drain_filter_polyfill"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "either"
@@ -406,6 +432,7 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+ "num_cpus",
 ]
 
 [[package]]
@@ -464,27 +491,14 @@ dependencies = [
  "gloo-net",
  "icondata",
  "leptos",
- "leptos_config",
- "leptos_dom",
- "leptos_hot_reload",
  "leptos_macro",
  "leptos_meta",
  "leptos_router",
- "leptos_router_macro",
- "leptos_server",
- "next_tuple",
  "opr",
  "opr-test-data",
- "reactive_graph",
- "reactive_stores_macro",
  "serde",
- "server_fn",
- "server_fn_macro",
- "server_fn_macro_default",
- "tachys",
  "thaw",
  "thaw_macro",
- "throw_error",
  "web-sys",
 ]
 
@@ -553,6 +567,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "html-escape"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "hydration_context"
-version = "0.2.0-rc0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3572b2778f74f110d907744b8d44be3602f1588aa5b7a098d8911a5d806b7f1"
+checksum = "d35485b3dcbf7e044b8f28c73f04f13e7b509c2466fd10cb2a8a447e38f8a93a"
 dependencies = [
  "futures",
  "once_cell",
@@ -796,6 +816,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,18 +832,19 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "leptos"
-version = "0.7.0-rc0"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf56a5fa2a3ca01c4b49255a66375612ddd138aeef2ffe11f7157ea3e349a82"
+checksum = "26b8731cb00f3f0894058155410b95c8955b17273181d2bc72600ab84edd24f1"
 dependencies = [
  "any_spawner",
  "cfg-if",
@@ -837,7 +867,7 @@ dependencies = [
  "server_fn",
  "slotmap",
  "tachys",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "throw_error",
  "typed-builder",
  "typed-builder-macro",
@@ -847,22 +877,22 @@ dependencies = [
 
 [[package]]
 name = "leptos_config"
-version = "0.7.0-rc0"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b972bec4a29c0a351fa54736b70eb9eda05938f732d1ec659f63887a5208c4bd"
+checksum = "5bae3e0ead5a7a814c8340eef7cb8b6cba364125bd8174b15dc9fe1b3cab7e03"
 dependencies = [
  "config",
  "regex",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "typed-builder",
 ]
 
 [[package]]
 name = "leptos_dom"
-version = "0.7.0-rc0"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ccab6ce79c7428460451e43edf052c5344a682058666f8ef19c19e898387fca"
+checksum = "f89d4eb263bd5a9e7c49f780f17063f15aca56fd638c90b9dfd5f4739152e87d"
 dependencies = [
  "js-sys",
  "or_poisoned",
@@ -875,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_hot_reload"
-version = "0.7.0-rc0"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1406f4641b5521324f3c5845f065e8a67b60147ee1aae56721dc2ba7c317dc2"
+checksum = "e80219388501d99b246f43b6e7d08a28f327cdd34ba630a35654d917f3e1788e"
 dependencies = [
  "anyhow",
  "camino",
@@ -893,15 +923,15 @@ dependencies = [
 
 [[package]]
 name = "leptos_macro"
-version = "0.7.0-rc0"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62fa728becd72d6f08cc9f93db3a712b4e068edb8b8af2da5b933bd3d1dcede"
+checksum = "e621f8f5342b9bdc93bb263b839cee7405027a74560425a2dabea9de7952b1fd"
 dependencies = [
  "attribute-derive",
  "cfg-if",
- "convert_case",
+ "convert_case 0.7.1",
  "html-escape",
- "itertools",
+ "itertools 0.14.0",
  "leptos_hot_reload",
  "prettyplease",
  "proc-macro-error2",
@@ -915,9 +945,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_meta"
-version = "0.7.0-rc0"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d88fb071600bfad69efea600fa5d80e215f8400debff546e329d03514fb7a04"
+checksum = "448a6387e9e2cccbb756f474a54e36a39557127a3b8e46744b6ef6372b50f575"
 dependencies = [
  "futures",
  "indexmap",
@@ -931,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_router"
-version = "0.7.0-rc0"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305d94867de5417d6d48e649ec29212df36200abb668ae6be0e4be3b2bcb4c1a"
+checksum = "4168ead6a9715daba953aa842795cb2ad81b6e011a15745bd3d1baf86f76de95"
 dependencies = [
  "any_spawner",
  "either_of",
@@ -947,7 +977,7 @@ dependencies = [
  "reactive_graph",
  "send_wrapper",
  "tachys",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "url",
  "wasm-bindgen",
  "web-sys",
@@ -955,20 +985,21 @@ dependencies = [
 
 [[package]]
 name = "leptos_router_macro"
-version = "0.7.0-rc0"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd154fe98477c03b331114adfac916f6a466985f52fbad27222f2d91b2641c8"
+checksum = "e31197af38d209ffc5d9f89715381c415a1570176f8d23455fbe00d148e79640"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
+ "syn",
 ]
 
 [[package]]
 name = "leptos_server"
-version = "0.7.0-rc0"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc869a5f93379eec0b4af337bfe953a6b6b7a20223c56ab6dbde7798d0296b4"
+checksum = "66985242812ec95e224fb48effe651ba02728beca92c461a9464c811a71aab11"
 dependencies = [
  "any_spawner",
  "base64",
@@ -1020,9 +1051,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "manyhow"
-version = "0.10.4"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91ea592d76c0b6471965708ccff7e6a5d277f676b90ab31f4d3f3fc77fade64"
+checksum = "b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587"
 dependencies = [
  "manyhow-macros",
  "proc-macro2",
@@ -1032,11 +1063,11 @@ dependencies = [
 
 [[package]]
 name = "manyhow-macros"
-version = "0.10.4"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64621e2c08f2576e4194ea8be11daf24ac01249a4f53cd8befcbb7077120ead"
+checksum = "46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495"
 dependencies = [
- "proc-macro-utils 0.8.0",
+ "proc-macro-utils",
  "proc-macro2",
  "quote",
 ]
@@ -1048,26 +1079,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "next_tuple"
-version = "0.1.0-rc0"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5154cd29823504d933fa19d02dd52f9f692cf9e337653f1409db70863fa5cd49"
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
+checksum = "60993920e071b0c9b66f14e2b32740a4e27ffc82854dcd72035887f336a09a28"
 
 [[package]]
 name = "num-traits"
@@ -1076,6 +1091,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1100,7 +1125,7 @@ version = "0.1.0"
 source = "git+https://github.com/ydirson/opr-rs?rev=854d192c8c85fe09b1b635e1c42e114363353cba#854d192c8c85fe09b1b635e1c42e114363353cba"
 dependencies = [
  "cfg-if",
- "itertools",
+ "itertools 0.13.0",
  "serde",
  "serde-aux",
 ]
@@ -1316,17 +1341,6 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
-dependencies = [
- "proc-macro2",
- "quote",
- "smallvec",
-]
-
-[[package]]
-name = "proc-macro-utils"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeaf08a13de400bc215877b5bdc088f241b12eb42f0a548d3390dc1c56bb7071"
@@ -1383,7 +1397,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82ebfb7faafadc06a7ab141a6f67bcfb24cb8beb158c6fe933f2f035afa99f35"
 dependencies = [
- "proc-macro-utils 0.10.0",
+ "proc-macro-utils",
  "proc-macro2",
  "quote",
  "syn",
@@ -1412,9 +1426,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "reactive_graph"
-version = "0.1.0-rc0"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e99ef30cfb23ffd2da6bbfcfa218c043003fdc40909102b52e9cc48707894e8"
+checksum = "76a0ccddbc11a648bd09761801dac9e3f246ef7641130987d6120fced22515e6"
 dependencies = [
  "any_spawner",
  "async-lock",
@@ -1427,18 +1441,18 @@ dependencies = [
  "send_wrapper",
  "serde",
  "slotmap",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "web-sys",
 ]
 
 [[package]]
 name = "reactive_stores"
-version = "0.1.0-rc0"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8062a7f178f934c17145a4dab0e8f0bf8879975ce72e1146b9bcd3bc6f342c19"
+checksum = "aadc7c19e3a360bf19cd595d2dc8b58ce67b9240b95a103fbc1317a8ff194237"
 dependencies = [
  "guardian",
- "itertools",
+ "itertools 0.14.0",
  "or_poisoned",
  "paste",
  "reactive_graph",
@@ -1448,11 +1462,11 @@ dependencies = [
 
 [[package]]
 name = "reactive_stores_macro"
-version = "0.1.0-rc0"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1262c9b4c1633da17472d69a2bc7d4709780c616e919b236e51949f160d2ab2e"
+checksum = "221095cb028dc51fbc2833743ea8b1a585da1a2af19b440b3528027495bf1f2d"
 dependencies = [
- "convert_case",
+ "convert_case 0.7.1",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -1517,6 +1531,12 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -1623,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "server_fn"
-version = "0.7.0-rc0"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2397ddd8c45c2379d3b596e978f8edc6548572c669730d0e69c8aac3117679c2"
+checksum = "8d05a9e3fd8d7404985418db38c6617cc793a1a27f398d4fbc9dfe8e41b804e6"
 dependencies = [
  "bytes",
  "const_format",
@@ -1641,7 +1661,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "server_fn_macro_default",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "throw_error",
  "url",
  "wasm-bindgen",
@@ -1653,12 +1673,12 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro"
-version = "0.7.0-rc0"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0965c30b56ec0f1cdd15464f4ce4abd83d06fe582c9c2fbcf61ee7e1453c805"
+checksum = "504b35e883267b3206317b46d02952ed7b8bf0e11b2e209e2eb453b609a5e052"
 dependencies = [
  "const_format",
- "convert_case",
+ "convert_case 0.6.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1667,9 +1687,9 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro_default"
-version = "0.7.0-rc0"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08bce1bdbe13e78fba58b3e1323b25597bc9c14ae59825299d7f6b10f819286"
+checksum = "eb8b274f568c94226a8045668554aace8142a59b8bca5414ac5a79627c825568"
 dependencies = [
  "server_fn_macro",
  "syn",
@@ -1753,18 +1773,20 @@ dependencies = [
 
 [[package]]
 name = "tachys"
-version = "0.1.0-rc0"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4061a2262552cb95969488266f015c14b52539e92d2ada077ac170b3a1b458ba"
+checksum = "8d42b7c1545705f77d871228eb52cbb1376b35dc0a237be9fb11e2d9e4e20818"
 dependencies = [
  "any_spawner",
+ "async-trait",
  "const_str_slice_concat",
  "drain_filter_polyfill",
+ "dyn-clone",
  "either_of",
  "futures",
  "html-escape",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "js-sys",
  "linear-map",
  "next_tuple",
@@ -1785,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "thaw"
-version = "0.4.0-beta4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4629bb9ebf56e2ffc2007b07f64169f60fe092b0ff5c8d5804c2f6fa7880ca10"
+checksum = "de5ae2cb227bc4f269dd8ba2efb730509f1008eb2dfebfc25facf9d74fc73451"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -1808,9 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "thaw_components"
-version = "0.2.0-beta4"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365d0982d55f2fc461d24bfbe583fbf596a7f15965d5cad5767a231d61cdd585"
+checksum = "8963ad3a3d5bf47a64abe12d1deaa4760774751f5953335fe0806fe35645fe3a"
 dependencies = [
  "cfg-if",
  "leptos",
@@ -1822,9 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "thaw_macro"
-version = "0.1.0-beta4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ce15b35d08a5a7e2ddfd54cb3b6261b17553e4e3c702c2074ed3716513da03"
+checksum = "5af50a5123e480e7ee8961e6456f63530816875d0a19cb73060b8e61dd2a95fb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1833,13 +1855,14 @@ dependencies = [
 
 [[package]]
 name = "thaw_utils"
-version = "0.1.0-beta4"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b99e68193442545c342f51b03f6e96a7738038a6f5355b467b4301ff062d16f"
+checksum = "c3a80028493030263acd93d3e21e57a2dd8dd6772c7439de02c4636c63bb1b6b"
 dependencies = [
  "cfg-if",
  "chrono",
  "leptos",
+ "reactive_stores",
  "send_wrapper",
  "wasm-bindgen",
  "web-sys",
@@ -1887,9 +1910,9 @@ dependencies = [
 
 [[package]]
 name = "throw_error"
-version = "0.2.0-rc0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f94a0abd02fad5a46b04748c89c32d2b5784bbb046fb6675f186e0bd45cd415c"
+checksum = "e4ef8bf264c6ae02a065a4a16553283f0656bd6266fc1fcb09fd2e6b5e91427b"
 dependencies = [
  "pin-project-lite",
 ]
@@ -1935,30 +1958,23 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
-
-[[package]]
 name = "typed-builder"
-version = "0.19.1"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06fbd5b8de54c5f7c91f6fe4cebb949be2125d7758e630bb58b1d831dbce600"
+checksum = "cd9d30e3a08026c78f246b173243cf07b3696d274debd26680773b6773c2afc7"
 dependencies = [
  "typed-builder-macro",
 ]
 
 [[package]]
 name = "typed-builder-macro"
-version = "0.19.1"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9534daa9fd3ed0bd911d462a37f172228077e7abf18c18a5f67199d959205f8"
+checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2008,9 +2024,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom",
  "js-sys",
@@ -2044,24 +2060,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -2070,21 +2086,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2092,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2105,15 +2122,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -2124,9 +2144,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,9 +136,9 @@ checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 
 [[package]]
 name = "cc"
-version = "1.1.36"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baee610e9452a8f6f0a1b6194ec09ff9e2d85dea54432acdae41aa0761c95d70"
+checksum = "1aeb932158bd710538c73702db6945cb68a8fb08c519e6e12706b94263b36db8"
 dependencies = [
  "shlex",
 ]
@@ -1453,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1521,9 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
@@ -1540,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1798,18 +1798,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2036,9 +2036,9 @@ checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -2049,9 +2049,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,8 +800,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "leptos"
 version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cbb3237c274dadf00dcc27db96c52601b40375117178fb24a991cda073624f0"
+source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
 dependencies = [
  "cfg-if",
  "leptos_config",
@@ -820,8 +819,7 @@ dependencies = [
 [[package]]
 name = "leptos_config"
 version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ed778611380ddea47568ac6ad6ec5158d39b5bd59e6c4dcd24efc15dc3dc0d"
+source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
 dependencies = [
  "config",
  "regex",
@@ -833,8 +831,7 @@ dependencies = [
 [[package]]
 name = "leptos_dom"
 version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8401c46c86c1f4c16dcb7881ed319fcdca9cda9b9e78a6088955cb423afcf119"
+source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
 dependencies = [
  "async-recursion",
  "cfg-if",
@@ -863,8 +860,7 @@ dependencies = [
 [[package]]
 name = "leptos_hot_reload"
 version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb53d4794240b684a2f4be224b84bee9e62d2abc498cf2bcd643cd565e01d96"
+source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
 dependencies = [
  "anyhow",
  "camino",
@@ -881,8 +877,7 @@ dependencies = [
 [[package]]
 name = "leptos_macro"
 version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b13bc3db70715cd8218c4535a5af3ae3c0e5fea6f018531fc339377b36bc0e0"
+source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
 dependencies = [
  "attribute-derive",
  "cfg-if",
@@ -904,8 +899,7 @@ dependencies = [
 [[package]]
 name = "leptos_meta"
 version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25acc2f63cf91932013e400a95bf6e35e5d3dbb44a7b7e25a8e3057d12005b3b"
+source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -918,8 +912,7 @@ dependencies = [
 [[package]]
 name = "leptos_reactive"
 version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4161acbf80f59219d8d14182371f57302bc7ff81ee41aba8ba1ff7295727f23"
+source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
 dependencies = [
  "base64",
  "cfg-if",
@@ -945,8 +938,7 @@ dependencies = [
 [[package]]
 name = "leptos_router"
 version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d71dea7d42c0d29c40842750232d3425ed1cf10e313a1f898076d20871dad32"
+source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
 dependencies = [
  "cfg-if",
  "gloo-net",
@@ -971,8 +963,7 @@ dependencies = [
 [[package]]
 name = "leptos_server"
 version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a97eb90a13f71500b831c7119ddd3bdd0d7ae0a6b0487cade4fddeed3b8c03f"
+source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
 dependencies = [
  "inventory",
  "lazy_static",
@@ -1079,8 +1070,7 @@ dependencies = [
 [[package]]
 name = "oco_ref"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51ebcefb2f0b9a5e0bea115532c8ae4215d1b01eff176d0f4ba4192895c2708"
+source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
 dependencies = [
  "serde",
  "thiserror",
@@ -1095,7 +1085,7 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 [[package]]
 name = "opr"
 version = "0.1.0"
-source = "git+https://github.com/ydirson/opr-rs?rev=68b2f48d1581d829bc7708ba6e024fc716cbb46a#68b2f48d1581d829bc7708ba6e024fc716cbb46a"
+source = "git+https://github.com/ydirson/opr-rs?rev=854d192c8c85fe09b1b635e1c42e114363353cba#854d192c8c85fe09b1b635e1c42e114363353cba"
 dependencies = [
  "cfg-if",
  "itertools 0.13.0",
@@ -1106,7 +1096,7 @@ dependencies = [
 [[package]]
 name = "opr-test-data"
 version = "0.0.1"
-source = "git+https://github.com/ydirson/opr-rs?rev=68b2f48d1581d829bc7708ba6e024fc716cbb46a#68b2f48d1581d829bc7708ba6e024fc716cbb46a"
+source = "git+https://github.com/ydirson/opr-rs?rev=854d192c8c85fe09b1b635e1c42e114363353cba#854d192c8c85fe09b1b635e1c42e114363353cba"
 dependencies = [
  "include_dir",
 ]
@@ -1590,8 +1580,7 @@ dependencies = [
 [[package]]
 name = "server_fn"
 version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fae7a3038a32e5a34ba32c6c45eb4852f8affaf8b794ebfcd4b1099e2d62ebe"
+source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
 dependencies = [
  "bytes",
  "ciborium",
@@ -1619,8 +1608,7 @@ dependencies = [
 [[package]]
 name = "server_fn_macro"
 version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faaaf648c6967aef78177c0610478abb5a3455811f401f3c62d10ae9bd3901a1"
+source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
 dependencies = [
  "const_format",
  "convert_case",
@@ -1633,8 +1621,7 @@ dependencies = [
 [[package]]
 name = "server_fn_macro_default"
 version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2aa8119b558a17992e0ac1fd07f080099564f24532858811ce04f742542440"
+source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
 dependencies = [
  "server_fn_macro",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,6 +475,7 @@ dependencies = [
  "opr",
  "opr-test-data",
  "reactive_graph",
+ "reactive_stores_macro",
  "serde",
  "server_fn",
  "server_fn_macro",
@@ -572,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "hydration_context"
-version = "0.2.0-gamma2"
+version = "0.2.0-rc0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da327cef06c53244d33f7c0d202f26693d787290905a5b2677a508768b1194c0"
+checksum = "b3572b2778f74f110d907744b8d44be3602f1588aa5b7a098d8911a5d806b7f1"
 dependencies = [
  "futures",
  "once_cell",
@@ -832,18 +833,18 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "leptos"
-version = "0.7.0-gamma2"
+version = "0.7.0-rc0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8364ee9e0d24df4223e05dd52f56acdf2f7839e4bdada4480418e69cb4e0c831"
+checksum = "ddf56a5fa2a3ca01c4b49255a66375612ddd138aeef2ffe11f7157ea3e349a82"
 dependencies = [
  "any_spawner",
  "cfg-if",
@@ -876,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_config"
-version = "0.7.0-gamma2"
+version = "0.7.0-rc0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84d5323ef20c99e407ba1a80f44c39820fc3e9a025e0fe430858b1a62b9acc0"
+checksum = "b972bec4a29c0a351fa54736b70eb9eda05938f732d1ec659f63887a5208c4bd"
 dependencies = [
  "config",
  "regex",
@@ -889,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_dom"
-version = "0.7.0-gamma2"
+version = "0.7.0-rc0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a46b55654b156018f8729770ab51162e530f1a7e5e7eae43deb4d8d78eb58"
+checksum = "3ccab6ce79c7428460451e43edf052c5344a682058666f8ef19c19e898387fca"
 dependencies = [
  "js-sys",
  "or_poisoned",
@@ -904,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_hot_reload"
-version = "0.7.0-gamma2"
+version = "0.7.0-rc0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "378d042feaf5eb03652bd8e5c01420afd50df1081251f84f29733dde5de223fe"
+checksum = "c1406f4641b5521324f3c5845f065e8a67b60147ee1aae56721dc2ba7c317dc2"
 dependencies = [
  "anyhow",
  "camino",
@@ -922,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_macro"
-version = "0.7.0-gamma2"
+version = "0.7.0-rc0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921cf1b8fc4aa10001083664492d68f7f60420c40f545a5fa5f974d8482099a8"
+checksum = "a62fa728becd72d6f08cc9f93db3a712b4e068edb8b8af2da5b933bd3d1dcede"
 dependencies = [
  "attribute-derive",
  "cfg-if",
@@ -944,9 +945,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_meta"
-version = "0.7.0-gamma2"
+version = "0.7.0-rc0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a1b999b1574abc17a07a68b54fb1f7aa670c50a60c0407b05fa26fdd4108458"
+checksum = "2d88fb071600bfad69efea600fa5d80e215f8400debff546e329d03514fb7a04"
 dependencies = [
  "futures",
  "indexmap",
@@ -960,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_router"
-version = "0.7.0-gamma2"
+version = "0.7.0-rc0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91a752fbf7aeaf68f56ec0eb59bda4f18293194268e16dd7ef8cf5e5b6356675"
+checksum = "305d94867de5417d6d48e649ec29212df36200abb668ae6be0e4be3b2bcb4c1a"
 dependencies = [
  "any_spawner",
  "either_of",
@@ -973,10 +974,8 @@ dependencies = [
  "leptos_router_macro",
  "once_cell",
  "or_poisoned",
- "paste",
  "reactive_graph",
  "send_wrapper",
- "serde",
  "tachys",
  "thiserror",
  "url",
@@ -986,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_router_macro"
-version = "0.7.0-gamma2"
+version = "0.7.0-rc0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc19f60e3687eb69ee7ea66cbf2f4032dcf473d6e56d340acff4eeb23c0a305"
+checksum = "cfd154fe98477c03b331114adfac916f6a466985f52fbad27222f2d91b2641c8"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -997,9 +996,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_server"
-version = "0.7.0-gamma2"
+version = "0.7.0-rc0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c981b0748be2de45ed7af9d7a0752bf8ec505b15f96e84bf88ca239857c585d"
+checksum = "7bc869a5f93379eec0b4af337bfe953a6b6b7a20223c56ab6dbde7798d0296b4"
 dependencies = [
  "any_spawner",
  "base64",
@@ -1086,9 +1085,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "next_tuple"
-version = "0.1.0-gamma2"
+version = "0.1.0-rc0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550cf708f0dd373c47d2d6092fc3c38826147afa57cf2f646ed7306b6b2a7f62"
+checksum = "5154cd29823504d933fa19d02dd52f9f692cf9e337653f1409db70863fa5cd49"
 
 [[package]]
 name = "nom"
@@ -1347,6 +1346,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1441,9 +1441,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "reactive_graph"
-version = "0.1.0-gamma2"
+version = "0.1.0-rc0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1278052e7c424405b17998339afb2959d97f4825f25d6f299bbb4c99dab747f"
+checksum = "1e99ef30cfb23ffd2da6bbfcfa218c043003fdc40909102b52e9cc48707894e8"
 dependencies = [
  "any_spawner",
  "async-lock",
@@ -1458,6 +1458,34 @@ dependencies = [
  "slotmap",
  "thiserror",
  "web-sys",
+]
+
+[[package]]
+name = "reactive_stores"
+version = "0.1.0-rc0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8062a7f178f934c17145a4dab0e8f0bf8879975ce72e1146b9bcd3bc6f342c19"
+dependencies = [
+ "guardian",
+ "itertools",
+ "or_poisoned",
+ "paste",
+ "reactive_graph",
+ "reactive_stores_macro",
+ "rustc-hash",
+]
+
+[[package]]
+name = "reactive_stores_macro"
+version = "0.1.0-rc0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1262c9b4c1633da17472d69a2bc7d4709780c616e919b236e51949f160d2ab2e"
+dependencies = [
+ "convert_case",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1613,9 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "server_fn"
-version = "0.7.0-gamma2"
+version = "0.7.0-rc0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a98570188735ac32205912d3460d7e12cfcf969bcd7d2b01c4c4f795711e3e"
+checksum = "2397ddd8c45c2379d3b596e978f8edc6548572c669730d0e69c8aac3117679c2"
 dependencies = [
  "bytes",
  "const_format",
@@ -1643,9 +1671,9 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro"
-version = "0.7.0-gamma2"
+version = "0.7.0-rc0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119cea4124c6acbd0c629716264908ac6970177a34b2a9bc0e1a75c2cebdbe37"
+checksum = "a0965c30b56ec0f1cdd15464f4ce4abd83d06fe582c9c2fbcf61ee7e1453c805"
 dependencies = [
  "const_format",
  "convert_case",
@@ -1657,9 +1685,9 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro_default"
-version = "0.7.0-gamma2"
+version = "0.7.0-rc0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa3b8af6a3f1ed342e245c22d493f17d63c08eb597bc4e9a0ce7dda125de6ca"
+checksum = "c08bce1bdbe13e78fba58b3e1323b25597bc9c14ae59825299d7f6b10f819286"
 dependencies = [
  "server_fn_macro",
  "syn",
@@ -1743,9 +1771,9 @@ dependencies = [
 
 [[package]]
 name = "tachys"
-version = "0.1.0-gamma2"
+version = "0.1.0-rc0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86db1124f46d9cc82beecac6448135cc2245e0edd5b533cac5ccfd5f8cf22e4c"
+checksum = "4061a2262552cb95969488266f015c14b52539e92d2ada077ac170b3a1b458ba"
 dependencies = [
  "any_spawner",
  "const_str_slice_concat",
@@ -1764,6 +1792,7 @@ dependencies = [
  "parking_lot",
  "paste",
  "reactive_graph",
+ "reactive_stores",
  "rustc-hash",
  "send_wrapper",
  "slotmap",
@@ -1774,8 +1803,9 @@ dependencies = [
 
 [[package]]
 name = "thaw"
-version = "0.4.0-beta3"
-source = "git+https://github.com/thaw-ui/thaw?rev=0c5cb880950ff2229ab2762bfa64a900b70a857d#0c5cb880950ff2229ab2762bfa64a900b70a857d"
+version = "0.4.0-beta4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4629bb9ebf56e2ffc2007b07f64169f60fe092b0ff5c8d5804c2f6fa7880ca10"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -1796,8 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "thaw_components"
-version = "0.2.0-beta3"
-source = "git+https://github.com/thaw-ui/thaw?rev=0c5cb880950ff2229ab2762bfa64a900b70a857d#0c5cb880950ff2229ab2762bfa64a900b70a857d"
+version = "0.2.0-beta4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "365d0982d55f2fc461d24bfbe583fbf596a7f15965d5cad5767a231d61cdd585"
 dependencies = [
  "cfg-if",
  "leptos",
@@ -1809,8 +1840,9 @@ dependencies = [
 
 [[package]]
 name = "thaw_macro"
-version = "0.1.0-beta3"
-source = "git+https://github.com/thaw-ui/thaw?rev=0c5cb880950ff2229ab2762bfa64a900b70a857d#0c5cb880950ff2229ab2762bfa64a900b70a857d"
+version = "0.1.0-beta4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ce15b35d08a5a7e2ddfd54cb3b6261b17553e4e3c702c2074ed3716513da03"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1819,8 +1851,9 @@ dependencies = [
 
 [[package]]
 name = "thaw_utils"
-version = "0.1.0-beta3"
-source = "git+https://github.com/thaw-ui/thaw?rev=0c5cb880950ff2229ab2762bfa64a900b70a857d#0c5cb880950ff2229ab2762bfa64a900b70a857d"
+version = "0.1.0-beta4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b99e68193442545c342f51b03f6e96a7738038a6f5355b467b4301ff062d16f"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -1852,9 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "throw_error"
-version = "0.2.0-gamma2"
+version = "0.2.0-rc0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4fd77a12226ed7f596d9b32d52c4cdaf82b9bbb99900e4479ff4b5614d26949"
+checksum = "f94a0abd02fad5a46b04748c89c32d2b5784bbb046fb6675f186e0bd45cd415c"
 dependencies = [
  "pin-project-lite",
 ]
@@ -2004,9 +2037,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2015,9 +2048,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
@@ -2030,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.45"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2042,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2052,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2065,15 +2098,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -2084,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ version = "0.1.0"
 dependencies = [
  "cfg-if",
  "console_error_panic_hook",
- "gloo-net 0.5.0",
+ "gloo-net",
  "icondata",
  "leptos",
  "leptos_macro",
@@ -447,27 +447,6 @@ dependencies = [
 
 [[package]]
 name = "gloo-net"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43aaa242d1239a8822c15c645f02166398da4f8b5c4bae795c1f5b44e9eee173"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-sink",
- "gloo-utils",
- "http 0.2.12",
- "js-sys",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06f627b1a58ca3d42b45d6104bf1e1a03799df472df00988b6ba21accc10580"
@@ -476,7 +455,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http 1.1.0",
+ "http",
  "js-sys",
  "pin-project",
  "serde",
@@ -529,17 +508,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
 dependencies = [
  "utf8-width",
-]
-
-[[package]]
-name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
 ]
 
 [[package]]
@@ -981,7 +949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d71dea7d42c0d29c40842750232d3425ed1cf10e313a1f898076d20871dad32"
 dependencies = [
  "cfg-if",
- "gloo-net 0.6.0",
+ "gloo-net",
  "itertools 0.12.1",
  "js-sys",
  "lazy_static",
@@ -1630,8 +1598,8 @@ dependencies = [
  "const_format",
  "dashmap",
  "futures",
- "gloo-net 0.6.0",
- "http 1.1.0",
+ "gloo-net",
+ "http",
  "js-sys",
  "once_cell",
  "send_wrapper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "any_spawner"
+version = "0.1.1"
+source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+dependencies = [
+ "futures",
+ "thiserror",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,14 +52,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-recursion"
-version = "1.1.1"
+name = "async-lock"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -154,30 +164,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "ciborium"
-version = "0.2.2"
+name = "codee"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+checksum = "5d3ad3122b0001c7f140cf4d605ef9a9e2c24d96ab0b4fb4347b76de2425f445"
 dependencies = [
- "ciborium-io",
- "ciborium-ll",
  "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -185,6 +179,15 @@ name = "collection_literals"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "186dce98367766de751c42c4f03970fc60fc012296e706ccbb9d5df9b6c1e271"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "config"
@@ -230,6 +233,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_str_slice_concat"
+version = "0.1.0"
+source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+
+[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,18 +253,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "crunchy"
-version = "0.2.2"
+name = "crossbeam-utils"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
+ "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -298,10 +307,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "either_of"
+version = "0.1.0"
+source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+dependencies = [
+ "pin-project-lite",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "event-listener"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fast-srgb8"
@@ -480,14 +518,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.4.1"
+name = "guardian"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
-dependencies = [
- "cfg-if",
- "crunchy",
-]
+checksum = "493913a18c0d7bebb75127a26a432162c59edbe06f6cf712001e3e769345e8b5"
 
 [[package]]
 name = "hashbrown"
@@ -519,6 +553,19 @@ dependencies = [
  "bytes",
  "fnv",
  "itoa",
+]
+
+[[package]]
+name = "hydration_context"
+version = "0.2.0-beta5"
+source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+dependencies = [
+ "futures",
+ "once_cell",
+ "or_poisoned",
+ "pin-project-lite",
+ "serde",
+ "throw_error",
 ]
 
 [[package]]
@@ -753,21 +800,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 
 [[package]]
-name = "inventory"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,24 +824,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "leptos"
-version = "0.6.15"
-source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
+version = "0.7.0-beta5"
+source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
 dependencies = [
+ "any_spawner",
  "cfg-if",
+ "either_of",
+ "futures",
+ "hydration_context",
  "leptos_config",
  "leptos_dom",
+ "leptos_hot_reload",
  "leptos_macro",
- "leptos_reactive",
  "leptos_server",
+ "oco_ref",
+ "or_poisoned",
+ "paste",
+ "reactive_graph",
+ "rustc-hash",
+ "send_wrapper",
+ "serde",
+ "serde_qs",
  "server_fn",
- "tracing",
+ "slotmap",
+ "tachys",
+ "thiserror",
+ "throw_error",
  "typed-builder",
  "typed-builder-macro",
  "wasm-bindgen",
@@ -818,8 +859,8 @@ dependencies = [
 
 [[package]]
 name = "leptos_config"
-version = "0.6.15"
-source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
+version = "0.7.0-beta5"
+source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
 dependencies = [
  "config",
  "regex",
@@ -830,37 +871,22 @@ dependencies = [
 
 [[package]]
 name = "leptos_dom"
-version = "0.6.15"
-source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
+version = "0.7.0-beta5"
+source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
 dependencies = [
- "async-recursion",
- "cfg-if",
- "drain_filter_polyfill",
- "futures",
- "getrandom",
- "html-escape",
- "indexmap",
- "itertools 0.12.1",
  "js-sys",
- "leptos_reactive",
- "once_cell",
- "pad-adapter",
- "paste",
- "rustc-hash",
- "serde",
- "serde_json",
- "server_fn",
- "smallvec",
- "tracing",
+ "or_poisoned",
+ "reactive_graph",
+ "send_wrapper",
+ "tachys",
  "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
 ]
 
 [[package]]
 name = "leptos_hot_reload"
-version = "0.6.15"
-source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
+version = "0.7.0-beta5"
+source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
 dependencies = [
  "anyhow",
  "camino",
@@ -876,14 +902,14 @@ dependencies = [
 
 [[package]]
 name = "leptos_macro"
-version = "0.6.15"
-source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
+version = "0.7.0-beta5"
+source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
 dependencies = [
  "attribute-derive",
  "cfg-if",
  "convert_case",
  "html-escape",
- "itertools 0.12.1",
+ "itertools",
  "leptos_hot_reload",
  "prettyplease",
  "proc-macro-error2",
@@ -892,87 +918,75 @@ dependencies = [
  "rstml",
  "server_fn_macro",
  "syn",
- "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "leptos_meta"
-version = "0.6.15"
-source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
+version = "0.7.0-beta5"
+source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
 dependencies = [
- "cfg-if",
- "indexmap",
- "leptos",
- "tracing",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "leptos_reactive"
-version = "0.6.15"
-source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
-dependencies = [
- "base64",
- "cfg-if",
  "futures",
  "indexmap",
- "js-sys",
- "oco_ref",
- "paste",
- "pin-project",
- "rustc-hash",
- "self_cell",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
- "slotmap",
- "thiserror",
- "tracing",
+ "leptos",
+ "once_cell",
+ "or_poisoned",
+ "send_wrapper",
  "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
 ]
 
 [[package]]
 name = "leptos_router"
-version = "0.6.15"
-source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
+version = "0.7.0-beta5"
+source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
 dependencies = [
- "cfg-if",
+ "any_spawner",
+ "either_of",
+ "futures",
  "gloo-net",
- "itertools 0.12.1",
  "js-sys",
- "lazy_static",
  "leptos",
- "linear-map",
+ "leptos_router_macro",
  "once_cell",
- "percent-encoding",
+ "or_poisoned",
+ "paste",
+ "reactive_graph",
  "send_wrapper",
  "serde",
- "serde_json",
- "serde_qs 0.13.0",
+ "tachys",
  "thiserror",
- "tracing",
+ "url",
  "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
 ]
 
 [[package]]
-name = "leptos_server"
-version = "0.6.15"
-source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
+name = "leptos_router_macro"
+version = "0.7.0-beta5"
+source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
 dependencies = [
- "inventory",
- "lazy_static",
- "leptos_macro",
- "leptos_reactive",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "leptos_server"
+version = "0.7.0-beta5"
+source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+dependencies = [
+ "any_spawner",
+ "base64",
+ "codee",
+ "futures",
+ "hydration_context",
+ "reactive_graph",
+ "send_wrapper",
  "serde",
+ "serde_json",
  "server_fn",
- "thiserror",
- "tracing",
+ "tachys",
 ]
 
 [[package]]
@@ -986,10 +1000,6 @@ name = "linear-map"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfae20f6b19ad527b550c223fddc3077a547fc70cda94b9b566575423fd303ee"
-dependencies = [
- "serde",
- "serde_test",
-]
 
 [[package]]
 name = "litemap"
@@ -1049,6 +1059,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "next_tuple"
+version = "0.1.0-beta5"
+source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,8 +1084,8 @@ dependencies = [
 
 [[package]]
 name = "oco_ref"
-version = "0.1.1"
-source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
+version = "0.2.0"
+source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
 dependencies = [
  "serde",
  "thiserror",
@@ -1088,7 +1103,7 @@ version = "0.1.0"
 source = "git+https://github.com/ydirson/opr-rs?rev=854d192c8c85fe09b1b635e1c42e114363353cba#854d192c8c85fe09b1b635e1c42e114363353cba"
 dependencies = [
  "cfg-if",
- "itertools 0.13.0",
+ "itertools",
  "serde",
  "serde-aux",
 ]
@@ -1102,10 +1117,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "pad-adapter"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d80efc4b6721e8be2a10a5df21a30fa0b470f1539e53d8b4e6e75faf938b63"
+name = "or_poisoned"
+version = "0.1.0"
+source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
 
 [[package]]
 name = "palette"
@@ -1130,6 +1144,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1391,6 +1411,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
+name = "reactive_graph"
+version = "0.1.0-beta5"
+source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+dependencies = [
+ "any_spawner",
+ "async-lock",
+ "futures",
+ "guardian",
+ "hydration_context",
+ "or_poisoned",
+ "pin-project-lite",
+ "rustc-hash",
+ "send_wrapper",
+ "serde",
+ "slotmap",
+ "thiserror",
+ "web-sys",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,10 +1470,11 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rstml"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe542870b8f59dd45ad11d382e5339c9a1047cde059be136a7016095bbdefa77"
+checksum = "51187e564f12336ef40cd04f6f4d805d6919188001dcf1e0a021898ea0fe28ce"
 dependencies = [
+ "derive-where",
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
@@ -1444,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "ryu"
@@ -1468,12 +1509,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "self_cell"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d369a96f978623eb3dc28807c4852d6cc617fed53da5d3c400feff1ef34a714a"
 
 [[package]]
 name = "send_wrapper"
@@ -1504,17 +1539,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-wasm-bindgen"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,17 +1563,6 @@ dependencies = [
 
 [[package]]
 name = "serde_qs"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0431a35568651e363364210c91983c1da5eb29404d9f0928b67d4ebcfa7d330c"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "serde_qs"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd34f36fe4c5ba9654417139a9b3a20d2e1de6012ee678ad14d240c22c78d8d6"
@@ -1569,21 +1582,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_test"
-version = "1.0.177"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f901ee573cab6b3060453d2d5f0bae4e6d628c23c0a962ff9b5f1d7c8d4f1ed"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "server_fn"
-version = "0.6.15"
-source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
+version = "0.7.0-beta5"
+source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
 dependencies = [
  "bytes",
- "ciborium",
  "const_format",
  "dashmap",
  "futures",
@@ -1591,12 +1594,14 @@ dependencies = [
  "http",
  "js-sys",
  "once_cell",
+ "pin-project-lite",
  "send_wrapper",
  "serde",
  "serde_json",
- "serde_qs 0.12.0",
+ "serde_qs",
  "server_fn_macro_default",
  "thiserror",
+ "throw_error",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1607,8 +1612,8 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro"
-version = "0.6.15"
-source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
+version = "0.7.0-beta5"
+source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
 dependencies = [
  "const_format",
  "convert_case",
@@ -1620,8 +1625,8 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro_default"
-version = "0.6.15"
-source = "git+https://github.com/leptos-rs/leptos?branch=leptos_0.6#bd15fc5e65a2aaa5167acfe96893afd2a2acf39a"
+version = "0.7.0-beta5"
+source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
 dependencies = [
  "server_fn_macro",
  "syn",
@@ -1654,7 +1659,6 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
 dependencies = [
- "serde",
  "version_check",
 ]
 
@@ -1705,9 +1709,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tachys"
+version = "0.1.0-beta5"
+source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+dependencies = [
+ "any_spawner",
+ "const_str_slice_concat",
+ "drain_filter_polyfill",
+ "either_of",
+ "futures",
+ "html-escape",
+ "indexmap",
+ "itertools",
+ "js-sys",
+ "linear-map",
+ "next_tuple",
+ "oco_ref",
+ "once_cell",
+ "or_poisoned",
+ "parking_lot",
+ "paste",
+ "reactive_graph",
+ "rustc-hash",
+ "send_wrapper",
+ "slotmap",
+ "throw_error",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "thaw"
-version = "0.3.4"
-source = "git+https://github.com/thaw-ui/thaw?branch=thaw-v0.3#23230a6d65a45e56c6bb4e52a34f6e217d4ba55c"
+version = "0.4.0-beta3"
+source = "git+https://github.com/thaw-ui/thaw?rev=dfd5ddd328f2886260069bce9b8150d2307967e8#dfd5ddd328f2886260069bce9b8150d2307967e8"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -1716,7 +1750,10 @@ dependencies = [
  "leptos",
  "num-traits",
  "palette",
+ "send_wrapper",
+ "slotmap",
  "thaw_components",
+ "thaw_macro",
  "thaw_utils",
  "uuid",
  "wasm-bindgen",
@@ -1725,24 +1762,36 @@ dependencies = [
 
 [[package]]
 name = "thaw_components"
-version = "0.1.4"
-source = "git+https://github.com/thaw-ui/thaw?branch=thaw-v0.3#23230a6d65a45e56c6bb4e52a34f6e217d4ba55c"
+version = "0.2.0-beta3"
+source = "git+https://github.com/thaw-ui/thaw?rev=dfd5ddd328f2886260069bce9b8150d2307967e8#dfd5ddd328f2886260069bce9b8150d2307967e8"
 dependencies = [
  "cfg-if",
  "leptos",
+ "send_wrapper",
  "thaw_utils",
  "uuid",
  "web-sys",
 ]
 
 [[package]]
+name = "thaw_macro"
+version = "0.1.0-beta3"
+source = "git+https://github.com/thaw-ui/thaw?rev=dfd5ddd328f2886260069bce9b8150d2307967e8#dfd5ddd328f2886260069bce9b8150d2307967e8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thaw_utils"
-version = "0.0.6"
-source = "git+https://github.com/thaw-ui/thaw?branch=thaw-v0.3#23230a6d65a45e56c6bb4e52a34f6e217d4ba55c"
+version = "0.1.0-beta3"
+source = "git+https://github.com/thaw-ui/thaw?rev=dfd5ddd328f2886260069bce9b8150d2307967e8#dfd5ddd328f2886260069bce9b8150d2307967e8"
 dependencies = [
  "cfg-if",
  "chrono",
  "leptos",
+ "send_wrapper",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -1765,6 +1814,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "throw_error"
+version = "0.2.0-beta5"
+source = "git+https://github.com/ydirson/leptos?branch=beta5#186f98fb0da1e06b6804391cab31424552a08c2c"
+dependencies = [
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1812,50 +1869,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing"
-version = "0.1.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
-dependencies = [
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
 name = "typed-builder"
-version = "0.18.2"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77739c880e00693faef3d65ea3aad725f196da38b22fdc7ea6ded6e1ce4d3add"
+checksum = "a06fbd5b8de54c5f7c91f6fe4cebb949be2125d7758e630bb58b1d831dbce600"
 dependencies = [
  "typed-builder-macro",
 ]
 
 [[package]]
 name = "typed-builder-macro"
-version = "0.18.2"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f718dfaf347dcb5b983bfc87608144b0bad87970aebcbea5ce44d2a30c08e63"
+checksum = "f9534daa9fd3ed0bd911d462a37f172228077e7abf18c18a5f67199d959205f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1916,6 +1942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,29 +8,29 @@ rust-version = "1.72"
 console_error_panic_hook = { version = "0.1.0", optional = true }
 gloo-net = ">=0.5, <0.7"
 icondata = { version = "0.4.0", default-features = false, features = ["ionicons"] }
-leptos = { version = "=0.7.0-rc0", default-features = false, features = ["csr"] }
-leptos_macro = { version = "=0.7.0-rc0", features = ["csr"] }
-leptos_meta = "=0.7.0-rc0"
-leptos_router = "=0.7.0-rc0"
+leptos = { version = "0.7.0", default-features = false, features = ["csr"] }
+leptos_macro = { version = "0.7.0", features = ["csr"] }
+leptos_meta = "0.7.0"
+leptos_router = "0.7.0"
 serde = { version = "1.0.0" }
-thaw = { version = "=0.4.0-beta4", features = ["csr"]}
+thaw = { version = "0.4.0", features = ["csr"]}
 
-# those we don't use directly but have to be in sync
-leptos_config = "=0.7.0-rc0"
-leptos_dom = "=0.7.0-rc0"
-leptos_hot_reload = "=0.7.0-rc0"
-leptos_router_macro = "=0.7.0-rc0"
-leptos_server = "=0.7.0-rc0"
-next_tuple = "=0.1.0-rc0"
-reactive_graph = "=0.1.0-rc0"
-reactive_stores_macro = "=0.1.0-rc0"
-server_fn = "=0.7.0-rc0"
-server_fn_macro = "=0.7.0-rc0"
-server_fn_macro_default = "=0.7.0-rc0"
-tachys = "=0.1.0-rc0"
-throw_error = "=0.2.0-rc0"
+# those we don't use directly but have to be in sync when using a prerelease
+#leptos_config = "=0.7.0-rc2"
+#leptos_dom = "=0.7.0-rc2"
+#leptos_hot_reload = "=0.7.0-rc2"
+#leptos_router_macro = "=0.7.0-rc2"
+#leptos_server = "=0.7.0-rc2"
+#next_tuple = "=0.1.0-rc2"
+#reactive_graph = "=0.1.0-rc2"
+#reactive_stores_macro = "=0.1.0-rc2"
+#server_fn = "=0.7.0-rc2"
+#server_fn_macro = "=0.7.0-rc2"
+#server_fn_macro_default = "=0.7.0-rc2.0"
+#tachys = "=0.1.0-rc2"
+#throw_error = "=0.2.0-rc2"
 
-thaw_macro = "=0.1.0-beta4"
+thaw_macro = "0.1.0"
 
 [patch.crates-io]
 #leptos = {path = "../leptos/leptos"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,7 @@ leptos_macro = { version = "0.6.0", features = ["csr"] }
 leptos_meta = { version = "0.6.0", features = ["csr"] }
 leptos_router = { version = "0.6.0", features = ["csr"] }
 serde = { version = "1.0.0" }
-
-[dependencies.leptonic]
-#version = "0.5.0"
-git = "https://github.com/ydirson/leptonic/"
-branch = "leptonic-0.5"
-#path = "../leptonic/leptonic"
-# leptonic does not like leptos' "nightly"
-features = ["csr"]
+thaw = { version = "0.3.3", features = ["csr"] }
 
 [build-dependencies.opr-test-data]
 git = "https://github.com/ydirson/opr-rs"
@@ -42,7 +35,3 @@ cfg-if = "1.0.0"
 [features]
 dev = ["dep:console_error_panic_hook"]
 local-files = ["dep:opr-test-data", "opr/local-files"]
-
-[package.metadata.leptonic]
-style-dir = "style"
-js-dir = "public/js"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,17 @@ leptos_meta = { version = "0.6.0", features = ["csr"] }
 leptos_router = { version = "0.6.0", features = ["csr"] }
 serde = { version = "1.0.0" }
 
+[patch.crates-io]
+#leptos = {path = "../leptos/leptos"}
+#leptos_macro = {path = "../leptos/leptos_macro"}
+#leptos_meta = {path = "../leptos/meta"}
+#leptos_router = {path = "../leptos/router"}
+
+leptos = {git = "https://github.com/leptos-rs/leptos", branch = "leptos_0.6"}
+leptos_macro = {git = "https://github.com/leptos-rs/leptos", branch = "leptos_0.6"}
+leptos_meta = {git = "https://github.com/leptos-rs/leptos", branch = "leptos_0.6"}
+leptos_router = {git = "https://github.com/leptos-rs/leptos", branch = "leptos_0.6"}
+
 [dependencies.thaw]
 features = ["csr"]
 #version = "0.3.4"
@@ -22,12 +33,14 @@ branch = "thaw-v0.3"
 [build-dependencies.opr-test-data]
 git = "https://github.com/ydirson/opr-rs"
 optional = true
-rev = "68b2f48d1581d829bc7708ba6e024fc716cbb46a"
-#path = "../opr-rs/opr-test-data"
+rev = "854d192c8c85fe09b1b635e1c42e114363353cba"
 [dependencies.opr]
 git = "https://github.com/ydirson/opr-rs"
-rev = "68b2f48d1581d829bc7708ba6e024fc716cbb46a"
-#path = "../opr-rs/opr"
+rev = "854d192c8c85fe09b1b635e1c42e114363353cba"
+
+#[patch."https://github.com/ydirson/opr-rs"]
+#opr = {path = "../opr-rs/opr"}
+#opr-test-data = {path = "../opr-rs/opr-test-data"}
 
 [dependencies.web-sys]
 version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,16 +2,18 @@
 name = "generals-familiar"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.72"
 
 [dependencies]
 console_error_panic_hook = { version = "0.1.0", optional = true }
 gloo-net = ">=0.5, <0.7"
 icondata = { version = "0.4.0", default-features = false, features = ["ionicons"] }
-leptos = { version = "0.6.11", default-features = false, features = ["csr"] }
-leptos_macro = { version = "0.6.0", features = ["csr"] }
-leptos_meta = { version = "0.6.0", features = ["csr"] }
-leptos_router = { version = "0.6.0", features = ["csr"] }
+leptos = { version = "0.7.0-beta5", default-features = false, features = ["csr"] }
+leptos_macro = { version = "0.7.0-beta5", features = ["csr"] }
+leptos_meta = "0.7.0-beta5"
+leptos_router = "0.7.0-beta5"
 serde = { version = "1.0.0" }
+thaw = { version = "0.4.0-beta3", features = ["csr"]}
 
 [patch.crates-io]
 #leptos = {path = "../leptos/leptos"}
@@ -19,16 +21,15 @@ serde = { version = "1.0.0" }
 #leptos_meta = {path = "../leptos/meta"}
 #leptos_router = {path = "../leptos/router"}
 
-leptos = {git = "https://github.com/leptos-rs/leptos", branch = "leptos_0.6"}
-leptos_macro = {git = "https://github.com/leptos-rs/leptos", branch = "leptos_0.6"}
-leptos_meta = {git = "https://github.com/leptos-rs/leptos", branch = "leptos_0.6"}
-leptos_router = {git = "https://github.com/leptos-rs/leptos", branch = "leptos_0.6"}
+leptos = {git = "https://github.com/ydirson/leptos", branch = "beta5"}
+leptos_macro = {git = "https://github.com/ydirson/leptos", branch = "beta5"}
+leptos_meta = {git = "https://github.com/ydirson/leptos", branch = "beta5"}
+leptos_router = {git = "https://github.com/ydirson/leptos", branch = "beta5"}
 
-[dependencies.thaw]
-features = ["csr"]
-#version = "0.3.4"
+[patch.crates-io.thaw]
+#path = "../thaw/thaw"
 git = "https://github.com/thaw-ui/thaw"
-branch = "thaw-v0.3"
+rev = "dfd5ddd328f2886260069bce9b8150d2307967e8"
 
 [build-dependencies.opr-test-data]
 git = "https://github.com/ydirson/opr-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 console_error_panic_hook = { version = "0.1.0", optional = true }
 gloo-net = "0.5"
+icondata = { version = "0.4.0", default-features = false, features = ["ionicons"] }
 leptos = { version = "0.6.11", default-features = false, features = ["csr"] }
 leptos_macro = { version = "0.6.0", features = ["csr"] }
 leptos_meta = { version = "0.6.0", features = ["csr"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,12 @@ leptos_macro = { version = "0.6.0", features = ["csr"] }
 leptos_meta = { version = "0.6.0", features = ["csr"] }
 leptos_router = { version = "0.6.0", features = ["csr"] }
 serde = { version = "1.0.0" }
-thaw = { version = "0.3.4", features = ["csr"] }
+
+[dependencies.thaw]
+features = ["csr"]
+#version = "0.3.4"
+git = "https://github.com/thaw-ui/thaw"
+branch = "thaw-v0.3"
 
 [build-dependencies.opr-test-data]
 git = "https://github.com/ydirson/opr-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ leptos_macro = { version = "=0.7.0-rc0", features = ["csr"] }
 leptos_meta = "=0.7.0-rc0"
 leptos_router = "=0.7.0-rc0"
 serde = { version = "1.0.0" }
-thaw = { version = "0.4.0-beta4", features = ["csr"]}
+thaw = { version = "=0.4.0-beta4", features = ["csr"]}
 
 # those we don't use directly but have to be in sync
 leptos_config = "=0.7.0-rc0"
@@ -29,6 +29,8 @@ server_fn_macro = "=0.7.0-rc0"
 server_fn_macro_default = "=0.7.0-rc0"
 tachys = "=0.1.0-rc0"
 throw_error = "=0.2.0-rc0"
+
+thaw_macro = "=0.1.0-beta4"
 
 [patch.crates-io]
 #leptos = {path = "../leptos/leptos"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ leptos_macro = { version = "0.6.0", features = ["csr"] }
 leptos_meta = { version = "0.6.0", features = ["csr"] }
 leptos_router = { version = "0.6.0", features = ["csr"] }
 serde = { version = "1.0.0" }
-thaw = { version = "0.3.3", features = ["csr"] }
+thaw = { version = "0.3.4", features = ["csr"] }
 
 [build-dependencies.opr-test-data]
 git = "https://github.com/ydirson/opr-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,26 @@ rust-version = "1.72"
 console_error_panic_hook = { version = "0.1.0", optional = true }
 gloo-net = ">=0.5, <0.7"
 icondata = { version = "0.4.0", default-features = false, features = ["ionicons"] }
-leptos = { version = "0.7.0-beta5", default-features = false, features = ["csr"] }
-leptos_macro = { version = "0.7.0-beta5", features = ["csr"] }
-leptos_meta = "0.7.0-beta5"
-leptos_router = "0.7.0-beta5"
+leptos = { version = "=0.7.0-gamma2", default-features = false, features = ["csr"] }
+leptos_macro = { version = "=0.7.0-gamma2", features = ["csr"] }
+leptos_meta = "=0.7.0-gamma2"
+leptos_router = "=0.7.0-gamma2"
 serde = { version = "1.0.0" }
 thaw = { version = "0.4.0-beta3", features = ["csr"]}
+
+# those we don't use directly but have to be in sync
+leptos_config = "=0.7.0-gamma2"
+leptos_dom = "=0.7.0-gamma2"
+leptos_hot_reload = "=0.7.0-gamma2"
+leptos_router_macro = "=0.7.0-gamma2"
+leptos_server = "=0.7.0-gamma2"
+next_tuple = "=0.1.0-gamma2"
+reactive_graph = "=0.1.0-gamma2"
+server_fn = "=0.7.0-gamma2"
+server_fn_macro = "=0.7.0-gamma2"
+server_fn_macro_default = "=0.7.0-gamma2"
+tachys = "=0.1.0-gamma2"
+throw_error = "=0.2.0-gamma2"
 
 [patch.crates-io]
 #leptos = {path = "../leptos/leptos"}
@@ -21,15 +35,15 @@ thaw = { version = "0.4.0-beta3", features = ["csr"]}
 #leptos_meta = {path = "../leptos/meta"}
 #leptos_router = {path = "../leptos/router"}
 
-leptos = {git = "https://github.com/ydirson/leptos", branch = "beta5"}
-leptos_macro = {git = "https://github.com/ydirson/leptos", branch = "beta5"}
-leptos_meta = {git = "https://github.com/ydirson/leptos", branch = "beta5"}
-leptos_router = {git = "https://github.com/ydirson/leptos", branch = "beta5"}
+#leptos = {git = "https://github.com/ydirson/leptos", branch = "beta5"}
+#leptos_macro = {git = "https://github.com/ydirson/leptos", branch = "beta5"}
+#leptos_meta = {git = "https://github.com/ydirson/leptos", branch = "beta5"}
+#leptos_router = {git = "https://github.com/ydirson/leptos", branch = "beta5"}
 
 [patch.crates-io.thaw]
 #path = "../thaw/thaw"
 git = "https://github.com/thaw-ui/thaw"
-rev = "dfd5ddd328f2886260069bce9b8150d2307967e8"
+rev = "0c5cb880950ff2229ab2762bfa64a900b70a857d"
 
 [build-dependencies.opr-test-data]
 git = "https://github.com/ydirson/opr-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,26 +8,27 @@ rust-version = "1.72"
 console_error_panic_hook = { version = "0.1.0", optional = true }
 gloo-net = ">=0.5, <0.7"
 icondata = { version = "0.4.0", default-features = false, features = ["ionicons"] }
-leptos = { version = "=0.7.0-gamma2", default-features = false, features = ["csr"] }
-leptos_macro = { version = "=0.7.0-gamma2", features = ["csr"] }
-leptos_meta = "=0.7.0-gamma2"
-leptos_router = "=0.7.0-gamma2"
+leptos = { version = "=0.7.0-rc0", default-features = false, features = ["csr"] }
+leptos_macro = { version = "=0.7.0-rc0", features = ["csr"] }
+leptos_meta = "=0.7.0-rc0"
+leptos_router = "=0.7.0-rc0"
 serde = { version = "1.0.0" }
-thaw = { version = "0.4.0-beta3", features = ["csr"]}
+thaw = { version = "0.4.0-beta4", features = ["csr"]}
 
 # those we don't use directly but have to be in sync
-leptos_config = "=0.7.0-gamma2"
-leptos_dom = "=0.7.0-gamma2"
-leptos_hot_reload = "=0.7.0-gamma2"
-leptos_router_macro = "=0.7.0-gamma2"
-leptos_server = "=0.7.0-gamma2"
-next_tuple = "=0.1.0-gamma2"
-reactive_graph = "=0.1.0-gamma2"
-server_fn = "=0.7.0-gamma2"
-server_fn_macro = "=0.7.0-gamma2"
-server_fn_macro_default = "=0.7.0-gamma2"
-tachys = "=0.1.0-gamma2"
-throw_error = "=0.2.0-gamma2"
+leptos_config = "=0.7.0-rc0"
+leptos_dom = "=0.7.0-rc0"
+leptos_hot_reload = "=0.7.0-rc0"
+leptos_router_macro = "=0.7.0-rc0"
+leptos_server = "=0.7.0-rc0"
+next_tuple = "=0.1.0-rc0"
+reactive_graph = "=0.1.0-rc0"
+reactive_stores_macro = "=0.1.0-rc0"
+server_fn = "=0.7.0-rc0"
+server_fn_macro = "=0.7.0-rc0"
+server_fn_macro_default = "=0.7.0-rc0"
+tachys = "=0.1.0-rc0"
+throw_error = "=0.2.0-rc0"
 
 [patch.crates-io]
 #leptos = {path = "../leptos/leptos"}
@@ -40,10 +41,10 @@ throw_error = "=0.2.0-gamma2"
 #leptos_meta = {git = "https://github.com/ydirson/leptos", branch = "beta5"}
 #leptos_router = {git = "https://github.com/ydirson/leptos", branch = "beta5"}
 
-[patch.crates-io.thaw]
-#path = "../thaw/thaw"
-git = "https://github.com/thaw-ui/thaw"
-rev = "0c5cb880950ff2229ab2762bfa64a900b70a857d"
+#[patch.crates-io.thaw]
+##path = "../thaw/thaw"
+#git = "https://github.com/thaw-ui/thaw"
+#rev = "8563f046b0b1b1aaa6016b88f21a5c30bc2fbdde"
 
 [build-dependencies.opr-test-data]
 git = "https://github.com/ydirson/opr-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 console_error_panic_hook = { version = "0.1.0", optional = true }
-gloo-net = "0.5"
+gloo-net = ">=0.5, <0.7"
 icondata = { version = "0.4.0", default-features = false, features = ["ionicons"] }
 leptos = { version = "0.6.11", default-features = false, features = ["csr"] }
 leptos_macro = { version = "0.6.0", features = ["csr"] }

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ to build a web application using a language more fun than Javascript.
 
 The UI is currently relying on the [Leptos
 framework](https://leptos.dev/) to support a component-based reactive
-approach, and the [Leptonic component library](https://leptonic.dev/).
+approach, and the [Thaw component library](https://crates.io/crates/thaw).
 I'm not really happy yet with the generated WASM size, so maybe
 technical choices will change at some point - at least this setup
 makes it really easy to prototype things.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ browser to access it - if you choose to build it yourself, just run
     full URL provided by "share as link"
   * show spells when needed (requires fetching json army book)
   * (bug) on army removal, removal link for previous armies are not updated
+  * (bug) when deselecting all armies, the army type is kept (as
+    reflected in titlebar, and in reported mismatch loading a new
+    matchup)
 * QoL
   * special rules
     * in DetailsDrawer, highlight occurrences of a rule when clicking

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -3,8 +3,6 @@
 ignore = [
     # files not impacting the app build
     "README.md",
-    # The Leptonic build writes these files. Not ignoring them could lead to infinite rebuilds when using `trunk serve`.
-    "./style/leptonic"
 ]
 
 [[hooks]]

--- a/src/main.rs
+++ b/src/main.rs
@@ -474,7 +474,7 @@ fn GroupDetails(group: Rc<opr::UnitGroup>,
                 .collect_view()
         }
 
-        // <SpecialRulesDefList group=Rc::clone(&group) army />
+        <SpecialRulesDefList group=Rc::clone(&group) army />
     }
 }
 
@@ -609,45 +609,45 @@ fn SpecialRulesList(special_rules: Vec<Rc<opr::SpecialRule>>) -> impl IntoView {
         .collect_view()
 }
 
-// #[component]
-// fn SpecialRulesDefList(group: Rc<opr::UnitGroup>,
-//                        army: Army,) -> impl IntoView {
-//     view! {
-//         <specialrules-def-list>
-//             {move || {
-//                 let group = Rc::clone(&group);
-//                 army.army_data.with(
-//                     move |army_data| {
-//                         if let Some(Ok(army_data)) = army_data {
-//                             // the rules def
-//                             let opr::Army{ref special_rules, ..} = **army_data;
-//                             let special_rules_def = special_rules;
+#[component]
+fn SpecialRulesDefList(group: Rc<opr::UnitGroup>,
+                       army: Army,) -> impl IntoView {
+    view! {
+        <specialrules-def-list>
+            {move || {
+                let group = Rc::clone(&group);
+                army.army_data.with(
+                    move |army_data| {
+                        if let Some(Ok(army_data)) = army_data {
+                            // the rules def
+                            let opr::Army{ref special_rules, ..} = **army_data;
+                            let special_rules_def = special_rules;
 
-//                             view!{
-//                                 {match common_rules_def() {
-//                                     Ok(common_rules_def) => view! {
-//                                         {rules_descriptions_from_list_for_group(
-//                                             Rc::clone(&group), &common_rules_def.clone())}
-//                                     }.into_view(),
-//                                     Err(message) => view! {
-//                                         <ltn::Alert variant=ltn::AlertVariant::Danger>
-//                                             <AlertContent slot>{message}</AlertContent>
-//                                         </ltn::Alert>
-//                                     }.into_view(),
-//                                 }}
-//                                 {rules_descriptions_from_list_for_group(
-//                                     Rc::clone(&group), special_rules_def)}
-//                             }.into_view()
-//                         } else {
-//                             // cannot happen - FIXME should pass opr::Army directly instead?
-//                             view!{}.into_view()
-//                         }
-//                     }
-//                 )
-//             }}
-//         </specialrules-def-list>
-//     }
-// }
+                            view!{
+                                {match common_rules_def() {
+                                    Ok(common_rules_def) => view! {
+                                        {rules_descriptions_from_list_for_group(
+                                            Rc::clone(&group), &common_rules_def.clone())}
+                                    }.into_view(),
+                                    Err(message) => view! {
+                                        <thaw::Alert variant=thaw::AlertVariant::Error>
+                                            {message}
+                                        </thaw::Alert>
+                                    }.into_view(),
+                                }}
+                                {rules_descriptions_from_list_for_group(
+                                    Rc::clone(&group), special_rules_def)}
+                            }.into_view()
+                        } else {
+                            // cannot happen - FIXME should pass opr::Army directly instead?
+                            view!{}.into_view()
+                        }
+                    }
+                )
+            }}
+        </specialrules-def-list>
+    }
+}
 
 /// extract common-rules definitions from the Context Resource, or an
 /// error string to display

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,13 +136,13 @@ fn App() -> impl IntoView {
             <thaw::Space class="app-contents" justify=thaw::SpaceJustify::Center>
                 <Show when=move || { army_ids.with(Result::is_ok) }
                       fallback=move || view! {
-                          // <SelectView alert_type={ltn::AlertVariant::Warn}
-                          //             message=army_ids.get().err().unwrap() />
+                          <SelectView alert_type={thaw::AlertVariant::Warning}
+                                      message=army_ids.get().err().unwrap() />
                       } >
                     <Show when=move || { ! army_ids.get().unwrap().is_empty() }
                           fallback=|| view! {
-                              // <SelectView alert_type={ltn::AlertVariant::Info}
-                              //             message="no army selected".to_string() />
+                              <SelectView alert_type={thaw::AlertVariant::Warning} // FIXME: Info
+                                          message="no army selected".to_string() />
                           } >
                         "Armies" // <ArmiesView army_ids=Signal::derive(move || army_ids.get().unwrap().clone()) />
                     </Show>
@@ -152,21 +152,21 @@ fn App() -> impl IntoView {
     }
 }
 
-// #[component]
-// fn SelectView(message: String, alert_type: ltn::AlertVariant) -> impl IntoView {
-//     // reset global game_system so a different can be enabled by new armies
-//     let app_game_system = expect_context::<RwSignal<Option<opr::GameSystem>>>();
-//     app_game_system.set(None);
+#[component]
+fn SelectView(message: String, alert_type: thaw::AlertVariant) -> impl IntoView {
+    // reset global game_system so a different can be enabled by new armies
+    let app_game_system = expect_context::<RwSignal<Option<opr::GameSystem>>>();
+    app_game_system.set(None);
 
-//     view! {
-//         <Title text="select armies"/>
-//         <ltn::Alert variant=alert_type>
-//             <AlertContent slot>{message}</AlertContent>
-//         </ltn::Alert>
+    view! {
+        <Title text="select armies"/>
+        <thaw::Alert variant=alert_type>
+            {message}
+        </thaw::Alert>
 
-//         <SampleMatchups/>
-//     }
-// }
+        // <SampleMatchups/>
+    }
+}
 
 // #[component]
 // fn SampleMatchups() -> impl IntoView {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,6 @@ fn main() {
     #[cfg(feature = "dev")]
     console_error_panic_hook::set_once();
 
-    provide_meta_context();
     mount_to_body(|| view! { <AppBoilerplate/> })
 }
 
@@ -65,6 +64,7 @@ where
 /// se, and mandatory parents of the app
 #[component]
 fn AppBoilerplate() -> impl IntoView {
+    provide_meta_context();
     let theme = RwSignal::new(thaw::Theme::light());
     let theme_class = Memo::new(move |_| {
         theme.with(|theme| format!("color-scheme--{}", theme.color.color_scheme))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,4 @@
 use gloo_net::http::Request;
-use leptonic::prelude as ltn;
-use leptonic::prelude::AlertContent;
 use leptos::*;
 use leptos_meta::{provide_meta_context, Title};
 use leptos_router as ltr;
@@ -67,597 +65,595 @@ where
 #[component]
 fn AppBoilerplate() -> impl IntoView {
     view! {
-        <ltn::Root default_theme=ltn::LeptonicTheme::default()>
-            <Title formatter=|text| format!("{APP_NAME} — {text}")/>
-            <ltn::Box style="min-height: 100vh;">
-                <ltr::Router fallback=|| view! {
-                    <ltn::Alert variant=ltn::AlertVariant::Danger>
-                        <AlertContent slot>"Bad URL (route not matched)"</AlertContent>
-                    </ltn::Alert>
-                }.into_view() >
-                    <App/>
-                </ltr::Router>
-            </ltn::Box>
-        </ltn::Root>
+        <Title formatter=|text| format!("{APP_NAME} — {text}")/>
+// <ltn::Box style="min-height: 100vh;">
+        <ltr::Router fallback=|| view! {
+            <thaw::Alert title="Bad URL" variant=thaw::AlertVariant::Error>
+                "route not matched."
+            </thaw::Alert>
+        }.into_view() >
+            "There will be an app." //<App/>
+        </ltr::Router>
+// </ltn::Box>
     }
 }
 
-#[derive(Params,PartialEq)]
-struct UrlQuery {
-    armies: Option<String>,
-}
+// #[derive(Params,PartialEq)]
+// struct UrlQuery {
+//     armies: Option<String>,
+// }
 
-/// the main application component
-#[component]
-fn App() -> impl IntoView {
-    let query = ltr::use_query::<UrlQuery>();
-    let game_system = create_rw_signal(None::<opr::GameSystem>);
-    provide_context(game_system);
+// /// the main application component
+// #[component]
+// fn App() -> impl IntoView {
+//     let query = ltr::use_query::<UrlQuery>();
+//     let game_system = create_rw_signal(None::<opr::GameSystem>);
+//     provide_context(game_system);
 
-    let common_rules: Resource<Option<opr::GameSystem>,
-                               Result<Rc<opr::CommonRules>, String>> =
-        create_resource(
-            move || game_system.get(),
-            |game_system| async move {
-                match game_system {
-                    Some(game_system) => {
-                        let url = opr::get_common_rules_url(game_system);
-                        load_json_from_url(&url).await
-                    },
-                    None => Err("no common-rules, game system not known yet".to_string()),
-                }
-            });
-    provide_context(common_rules);
+//     let common_rules: Resource<Option<opr::GameSystem>,
+//                                Result<Rc<opr::CommonRules>, String>> =
+//         create_resource(
+//             move || game_system.get(),
+//             |game_system| async move {
+//                 match game_system {
+//                     Some(game_system) => {
+//                         let url = opr::get_common_rules_url(game_system);
+//                         load_json_from_url(&url).await
+//                     },
+//                     None => Err("no common-rules, game system not known yet".to_string()),
+//                 }
+//             });
+//     provide_context(common_rules);
 
-    let army_ids = Signal::derive(move || {
-        query.with(|params| {
-            match params.as_ref().map(|params| params.armies.clone()) {
-                Ok(None) => Ok(vec!()),
-                Err(err) => Err(err.to_string()),
-                Ok(Some(armies_string)) => {
-                    let v = armies_string
-                        .split(',')
-                        .map(|s| s.to_string())
-                        .collect::<Vec<String>>();
-                    Ok(v)
-                },
-            }
-        })
-    });
-    view! {
-        <ltn::AppBar>
-            <h1>
-                {APP_NAME}
-                {move || match game_system.get() {
-                    Some(game_system) => format!(" - {game_system}"),
-                    None => "".to_string(),
-                }}
-            </h1>
-            <ltn::ThemeToggle off=ltn::LeptonicTheme::Light on=ltn::LeptonicTheme::Dark/>
-        </ltn::AppBar>
-        <ltn::Box style="padding: 0 1em 1em 1em;">
-            <Show when=move || { army_ids.with(Result::is_ok) }
-                  fallback=move || view! {
-                      <SelectView alert_type={ltn::AlertVariant::Warn}
-                                  message=army_ids.get().err().unwrap() />
-                  } >
-                <Show when=move || { ! army_ids.get().unwrap().is_empty() }
-                      fallback=|| view! {
-                          <SelectView alert_type={ltn::AlertVariant::Info}
-                                      message="no army selected".to_string() />
-                      } >
-                    <ArmiesView army_ids=Signal::derive(move || army_ids.get().unwrap().clone()) />
-                </Show>
-            </Show>
-        </ltn::Box>
-    }
-}
+//     let army_ids = Signal::derive(move || {
+//         query.with(|params| {
+//             match params.as_ref().map(|params| params.armies.clone()) {
+//                 Ok(None) => Ok(vec!()),
+//                 Err(err) => Err(err.to_string()),
+//                 Ok(Some(armies_string)) => {
+//                     let v = armies_string
+//                         .split(',')
+//                         .map(|s| s.to_string())
+//                         .collect::<Vec<String>>();
+//                     Ok(v)
+//                 },
+//             }
+//         })
+//     });
+//     view! {
+//         <ltn::AppBar>
+//             <h1>
+//                 {APP_NAME}
+//                 {move || match game_system.get() {
+//                     Some(game_system) => format!(" - {game_system}"),
+//                     None => "".to_string(),
+//                 }}
+//             </h1>
+//             <ltn::ThemeToggle off=ltn::LeptonicTheme::Light on=ltn::LeptonicTheme::Dark/>
+//         </ltn::AppBar>
+//         <ltn::Box style="padding: 0 1em 1em 1em;">
+//             <Show when=move || { army_ids.with(Result::is_ok) }
+//                   fallback=move || view! {
+//                       <SelectView alert_type={ltn::AlertVariant::Warn}
+//                                   message=army_ids.get().err().unwrap() />
+//                   } >
+//                 <Show when=move || { ! army_ids.get().unwrap().is_empty() }
+//                       fallback=|| view! {
+//                           <SelectView alert_type={ltn::AlertVariant::Info}
+//                                       message="no army selected".to_string() />
+//                       } >
+//                     <ArmiesView army_ids=Signal::derive(move || army_ids.get().unwrap().clone()) />
+//                 </Show>
+//             </Show>
+//         </ltn::Box>
+//     }
+// }
 
-#[component]
-fn SelectView(message: String, alert_type: ltn::AlertVariant) -> impl IntoView {
-    // reset global game_system so a different can be enabled by new armies
-    let app_game_system = expect_context::<RwSignal<Option<opr::GameSystem>>>();
-    app_game_system.set(None);
+// #[component]
+// fn SelectView(message: String, alert_type: ltn::AlertVariant) -> impl IntoView {
+//     // reset global game_system so a different can be enabled by new armies
+//     let app_game_system = expect_context::<RwSignal<Option<opr::GameSystem>>>();
+//     app_game_system.set(None);
 
-    view! {
-        <Title text="select armies"/>
-        <ltn::Alert variant=alert_type>
-            <AlertContent slot>{message}</AlertContent>
-        </ltn::Alert>
+//     view! {
+//         <Title text="select armies"/>
+//         <ltn::Alert variant=alert_type>
+//             <AlertContent slot>{message}</AlertContent>
+//         </ltn::Alert>
 
-        <SampleMatchups/>
-    }
-}
+//         <SampleMatchups/>
+//     }
+// }
 
-#[component]
-fn SampleMatchups() -> impl IntoView {
-    view! {
-        <h3> "Notice" </h3>
-        <p>
-            "This app is a technical preview. "
-            "Remember to use smartphones in landscape mode."
-        </p>
-        <h3> "Sample matchups" </h3>
-        <ltn::TableContainer>
-            <ltn::Table bordered=true hoverable=true>
-                <ltn::TableBody>
-                    <ltn::TableRow>
-                        <ltn::TableCell>
-                            <em>"Grimdark Future — "</em>
-                            <a href="./?armies=Rrlct39EGuct,p2KIbSBOYpSB">
-                            "Robots Legion vs. Prime Brothers" </a>
-                        </ltn::TableCell>
-                    </ltn::TableRow>
-                    <ltn::TableRow>
-                        <ltn::TableCell>
-                            <em>"Grimdark Future — "</em>
-                            <a href="./?armies=Mlwpoh1AGLC2">
-                            "Robots Legion (single list)" </a>
-                        </ltn::TableCell>
-                    </ltn::TableRow>
-                    <ltn::TableRow>
-                        <ltn::TableCell>
-                            <em>"Age of Fantasy: Skirmish — "</em>
-                            <a href="./?armies=zhz5uajqHdt5,ZTgIvcYABynP">
-                            "War Disciples vs. Eternal Wardens" </a>
-                        </ltn::TableCell>
-                    </ltn::TableRow>
-                </ltn::TableBody>
-            </ltn::Table>
-        </ltn::TableContainer>
-    }
-}
+// #[component]
+// fn SampleMatchups() -> impl IntoView {
+//     view! {
+//         <h3> "Notice" </h3>
+//         <p>
+//             "This app is a technical preview. "
+//             "Remember to use smartphones in landscape mode."
+//         </p>
+//         <h3> "Sample matchups" </h3>
+//         <ltn::TableContainer>
+//             <ltn::Table bordered=true hoverable=true>
+//                 <ltn::TableBody>
+//                     <ltn::TableRow>
+//                         <ltn::TableCell>
+//                             <em>"Grimdark Future — "</em>
+//                             <a href="./?armies=Rrlct39EGuct,p2KIbSBOYpSB">
+//                             "Robots Legion vs. Prime Brothers" </a>
+//                         </ltn::TableCell>
+//                     </ltn::TableRow>
+//                     <ltn::TableRow>
+//                         <ltn::TableCell>
+//                             <em>"Grimdark Future — "</em>
+//                             <a href="./?armies=Mlwpoh1AGLC2">
+//                             "Robots Legion (single list)" </a>
+//                         </ltn::TableCell>
+//                     </ltn::TableRow>
+//                     <ltn::TableRow>
+//                         <ltn::TableCell>
+//                             <em>"Age of Fantasy: Skirmish — "</em>
+//                             <a href="./?armies=zhz5uajqHdt5,ZTgIvcYABynP">
+//                             "War Disciples vs. Eternal Wardens" </a>
+//                         </ltn::TableCell>
+//                     </ltn::TableRow>
+//                 </ltn::TableBody>
+//             </ltn::Table>
+//         </ltn::TableContainer>
+//     }
+// }
 
-/// the main view, showing multiple armies and providing detail
-/// drawers for selections
-#[component]
-fn ArmiesView(army_ids: Signal<Vec<String>>) -> impl IntoView {
-    provide_context(army_ids);
-    view! {
-        <Title text="view armies" />
-        <ltn::Stack orientation=ltn::StackOrientation::Horizontal
-                    spacing=ltn::Size::Em(1.0)
-                    class="army_view" >
-            <For each=move || army_ids.with(|ids| ids.iter()
-                                            .map(String::clone)
-                                            .enumerate().collect::<Vec<(usize, String)>>())
-                 key=|k: &(usize, String)| k.clone()
-                 children=move |(i, id)| view! {
-                     <ArmyContainer army={Army::new(Signal::derive(move || id.clone()))}
-                                    side={if i == 0 {ltn::DrawerSide::Left}
-                                          else {ltn::DrawerSide::Right}} />
-                 }
-             />
-        </ltn::Stack>
-    }
-}
+// /// the main view, showing multiple armies and providing detail
+// /// drawers for selections
+// #[component]
+// fn ArmiesView(army_ids: Signal<Vec<String>>) -> impl IntoView {
+//     provide_context(army_ids);
+//     view! {
+//         <Title text="view armies" />
+//         <ltn::Stack orientation=ltn::StackOrientation::Horizontal
+//                     spacing=ltn::Size::Em(1.0)
+//                     class="army_view" >
+//             <For each=move || army_ids.with(|ids| ids.iter()
+//                                             .map(String::clone)
+//                                             .enumerate().collect::<Vec<(usize, String)>>())
+//                  key=|k: &(usize, String)| k.clone()
+//                  children=move |(i, id)| view! {
+//                      <ArmyContainer army={Army::new(Signal::derive(move || id.clone()))}
+//                                     side={if i == 0 {ltn::DrawerSide::Left}
+//                                           else {ltn::DrawerSide::Right}} />
+//                  }
+//              />
+//         </ltn::Stack>
+//     }
+// }
 
-#[derive(Clone)]
-struct DrawerControl {
-    shown: RwSignal<bool>,
-}
-impl Default for DrawerControl {
-    fn default() -> Self {
-        DrawerControl {
-            shown: create_rw_signal(false),
-        }
-    }
-}
+// #[derive(Clone)]
+// struct DrawerControl {
+//     shown: RwSignal<bool>,
+// }
+// impl Default for DrawerControl {
+//     fn default() -> Self {
+//         DrawerControl {
+//             shown: create_rw_signal(false),
+//         }
+//     }
+// }
 
-/// A component container for the army list and the drawer, so they
-/// can share a common context
-#[component]
-fn ArmyContainer(army: Army, side: ltn::DrawerSide) -> impl IntoView {
-    // the `shown` status can be changed by eg. selecting in the army
-    // list, or using close button in the drawer itself
-    let drawer_control = DrawerControl::default();
-    let shown = drawer_control.shown.clone();
-    create_effect(move |_| {
-        shown.set(army.unit_selection.with(Option::is_some));
-    });
+// /// A component container for the army list and the drawer, so they
+// /// can share a common context
+// #[component]
+// fn ArmyContainer(army: Army, side: ltn::DrawerSide) -> impl IntoView {
+//     // the `shown` status can be changed by eg. selecting in the army
+//     // list, or using close button in the drawer itself
+//     let drawer_control = DrawerControl::default();
+//     let shown = drawer_control.shown.clone();
+//     create_effect(move |_| {
+//         shown.set(army.unit_selection.with(Option::is_some));
+//     });
 
-    view! {
-        <Provider value=drawer_control >
-            <DetailsDrawer side army=army.clone() />
-            <ArmyList army />
-        </Provider>
-    }
-}
+//     view! {
+//         <Provider value=drawer_control >
+//             <DetailsDrawer side army=army.clone() />
+//             <ArmyList army />
+//         </Provider>
+//     }
+// }
 
-#[component]
-fn ArmyList(army: Army,
-) -> impl IntoView {
-    let app_game_system = expect_context::<RwSignal<Option<opr::GameSystem>>>();
-    view! {
-        <ltn::Stack spacing=ltn::Size::Em(0.5) class="army_list" >
-        { move || {
-            army.army_data.with(
-                |army_data| match army_data {
-                    None => view! { <h2>"Loading..."</h2> }.into_view(),
-                    Some(Err(message)) => {
-                        let message = message.clone();
-                        let army_id = army.army_id.get();
-                        view! {
-                            <ltn::Stack spacing=ltn::Size::Em(0.5)
-                                        orientation=ltn::StackOrientation::Horizontal >
-                                <ltn::Alert variant=ltn::AlertVariant::Danger>
-                                    <AlertContent slot>{message}</AlertContent>
-                                </ltn::Alert>
-                                // FIXME: hack to have the button on errors have the same
-                                // size as the one on titles
-                                <span style="font-size: var(--typography-h2-font-size);">
-                                    <RemoveArmyButton army_id />
-                                </span>
-                            </ltn::Stack>
-                        }.into_view()
-                    },
-                    Some(Ok(army_data)) => {
-                        let opr::Army{ref game_system, ref name, ref unit_groups, ..} = **army_data;
-                        let game_system = game_system.clone();
-                        let name = Rc::clone(name);
-                        let unit_groups = unit_groups.clone();
+// #[component]
+// fn ArmyList(army: Army,
+// ) -> impl IntoView {
+//     let app_game_system = expect_context::<RwSignal<Option<opr::GameSystem>>>();
+//     view! {
+//         <ltn::Stack spacing=ltn::Size::Em(0.5) class="army_list" >
+//         { move || {
+//             army.army_data.with(
+//                 |army_data| match army_data {
+//                     None => view! { <h2>"Loading..."</h2> }.into_view(),
+//                     Some(Err(message)) => {
+//                         let message = message.clone();
+//                         let army_id = army.army_id.get();
+//                         view! {
+//                             <ltn::Stack spacing=ltn::Size::Em(0.5)
+//                                         orientation=ltn::StackOrientation::Horizontal >
+//                                 <ltn::Alert variant=ltn::AlertVariant::Danger>
+//                                     <AlertContent slot>{message}</AlertContent>
+//                                 </ltn::Alert>
+//                                 // FIXME: hack to have the button on errors have the same
+//                                 // size as the one on titles
+//                                 <span style="font-size: var(--typography-h2-font-size);">
+//                                     <RemoveArmyButton army_id />
+//                                 </span>
+//                             </ltn::Stack>
+//                         }.into_view()
+//                     },
+//                     Some(Ok(army_data)) => {
+//                         let opr::Army{ref game_system, ref name, ref unit_groups, ..} = **army_data;
+//                         let game_system = game_system.clone();
+//                         let name = Rc::clone(name);
+//                         let unit_groups = unit_groups.clone();
 
-                        // since we are recreating an ArmyList, the Army must have changed
-                        // (or this is an over-refresh bug), drawer is outdated so close it
-                        let shown = use_context::<DrawerControl>().unwrap().shown;
-                        shown.set(false);
+//                         // since we are recreating an ArmyList, the Army must have changed
+//                         // (or this is an over-refresh bug), drawer is outdated so close it
+//                         let shown = use_context::<DrawerControl>().unwrap().shown;
+//                         shown.set(false);
 
-                        let check_inconsistency = move || {
-                            match game_system.clone() {
-                                Err(e) => Some(e),
-                                Ok(game_system) => match app_game_system.get() {
-                                    // not yet set: set it, ok
-                                    None => {
-                                        app_game_system.set(Some(game_system));
-                                        None },
-                                    // already set and matching this army: ok
-                                    Some(app_game_system) if game_system == app_game_system
-                                        => None,
-                                    // already set and not matching: KO
-                                    Some(_)
-                                        => Some(format!("game system mismatch: {game_system}")),
-                                }
-                            }
-                        };
-                        view! {
-                            {move || {
-                                let name = Rc::clone(&name);
-                                let army_id = army.army_id.get();
-                                let af_url = format!("{}?id={army_id}", opr::ARMYFORGE_SHARE_URL);
-                                view! {
-                                    <h2>
-                                        <a target="_blank" href={af_url}>{name}</a>
-                                        <RemoveArmyButton army_id />
-                                    </h2>
-                                }
-                            }}
-                            {move || {
-                                let check_inconsistency = check_inconsistency();
-                                if check_inconsistency.is_none() {
-                                    view! {
-                                        <UnitsList unit_groups={unit_groups.clone()}
-                                                   select_unit=army.unit_selection />
-                                    }.into_view()
-                                } else {
-                                    view! {
-                                        <ltn::Alert variant=ltn::AlertVariant::Danger>
-                                            <AlertContent slot>
-                                                {check_inconsistency.unwrap()}
-                                            </AlertContent>
-                                        </ltn::Alert>
-                                    }.into_view()
-                                }
-                            }}
-                        }.into_view()
-                    },
-                }
-            )
-        }}
-        </ltn::Stack>
-    }
-}
+//                         let check_inconsistency = move || {
+//                             match game_system.clone() {
+//                                 Err(e) => Some(e),
+//                                 Ok(game_system) => match app_game_system.get() {
+//                                     // not yet set: set it, ok
+//                                     None => {
+//                                         app_game_system.set(Some(game_system));
+//                                         None },
+//                                     // already set and matching this army: ok
+//                                     Some(app_game_system) if game_system == app_game_system
+//                                         => None,
+//                                     // already set and not matching: KO
+//                                     Some(_)
+//                                         => Some(format!("game system mismatch: {game_system}")),
+//                                 }
+//                             }
+//                         };
+//                         view! {
+//                             {move || {
+//                                 let name = Rc::clone(&name);
+//                                 let army_id = army.army_id.get();
+//                                 let af_url = format!("{}?id={army_id}", opr::ARMYFORGE_SHARE_URL);
+//                                 view! {
+//                                     <h2>
+//                                         <a target="_blank" href={af_url}>{name}</a>
+//                                         <RemoveArmyButton army_id />
+//                                     </h2>
+//                                 }
+//                             }}
+//                             {move || {
+//                                 let check_inconsistency = check_inconsistency();
+//                                 if check_inconsistency.is_none() {
+//                                     view! {
+//                                         <UnitsList unit_groups={unit_groups.clone()}
+//                                                    select_unit=army.unit_selection />
+//                                     }.into_view()
+//                                 } else {
+//                                     view! {
+//                                         <ltn::Alert variant=ltn::AlertVariant::Danger>
+//                                             <AlertContent slot>
+//                                                 {check_inconsistency.unwrap()}
+//                                             </AlertContent>
+//                                         </ltn::Alert>
+//                                     }.into_view()
+//                                 }
+//                             }}
+//                         }.into_view()
+//                     },
+//                 }
+//             )
+//         }}
+//         </ltn::Stack>
+//     }
+// }
 
-#[component]
-fn UnitsList(unit_groups: Vec<Rc<opr::UnitGroup>>,
-             select_unit: RwSignal<Option<Rc<opr::UnitGroup>>>, // FIXME only need WriteSignal here
-) -> impl IntoView {
-    let (selected_row_num, set_selected_row_num) = create_signal(None::<usize>);
-    view! {
-        <ltn::TableContainer>
-            <ltn::Table bordered=true hoverable=true>
-                <ltn::TableBody>
-                    {move || {
-                        unit_groups
-                            .clone()
-                            .into_iter()
-                            .enumerate()
-                            .map(|(i, group)| {
-                                let group_name = (*group).formatted_name();
-                                //let opr::Unit{..} = *unit;
-                                view! {
-                                    // FIXME this ought to be a ltn::TableRow, which does
-                                    // not allow for dynamic classes or even for class
-                                    <leptonic-table-row
-                                         class:selected=move || {
-                                             matches!(selected_row_num.get(),
-                                                      Some(index) if index == i)
-                                         }
-                                         on:click=move |_| {
-                                             select_unit.set(Some(group.clone()));
-                                             set_selected_row_num.set(Some(i));
-                                    }>
-                                        <ltn::TableCell> {group_name} </ltn::TableCell>
-                                    </leptonic-table-row>
-                                }
-                            })
-                            .collect_view()
-                    }}
-                </ltn::TableBody>
-            </ltn::Table>
-        </ltn::TableContainer>
-    }
-}
+// #[component]
+// fn UnitsList(unit_groups: Vec<Rc<opr::UnitGroup>>,
+//              select_unit: RwSignal<Option<Rc<opr::UnitGroup>>>, // FIXME only need WriteSignal here
+// ) -> impl IntoView {
+//     let (selected_row_num, set_selected_row_num) = create_signal(None::<usize>);
+//     view! {
+//         <ltn::TableContainer>
+//             <ltn::Table bordered=true hoverable=true>
+//                 <ltn::TableBody>
+//                     {move || {
+//                         unit_groups
+//                             .clone()
+//                             .into_iter()
+//                             .enumerate()
+//                             .map(|(i, group)| {
+//                                 let group_name = (*group).formatted_name();
+//                                 //let opr::Unit{..} = *unit;
+//                                 view! {
+//                                     // FIXME this ought to be a ltn::TableRow, which does
+//                                     // not allow for dynamic classes or even for class
+//                                     <leptonic-table-row
+//                                          class:selected=move || {
+//                                              matches!(selected_row_num.get(),
+//                                                       Some(index) if index == i)
+//                                          }
+//                                          on:click=move |_| {
+//                                              select_unit.set(Some(group.clone()));
+//                                              set_selected_row_num.set(Some(i));
+//                                     }>
+//                                         <ltn::TableCell> {group_name} </ltn::TableCell>
+//                                     </leptonic-table-row>
+//                                 }
+//                             })
+//                             .collect_view()
+//                     }}
+//                 </ltn::TableBody>
+//             </ltn::Table>
+//         </ltn::TableContainer>
+//     }
+// }
 
-#[component]
-fn RemoveArmyButton(army_id: String) -> impl IntoView {
-    let mut ids =
-        use_context::<Signal<Vec<String>>>()
-        .expect("should find army_ids in context")
-        .get();
-    ids.remove(ids.iter().position(|x| *x == army_id)
-               .expect("id should be in the list to remove it"));
-    let remove_army_url = if ids.is_empty() {
-        "./".to_string()
-    } else {
-        format!("./?armies={}", ids.join(","))
-    };
+// #[component]
+// fn RemoveArmyButton(army_id: String) -> impl IntoView {
+//     let mut ids =
+//         use_context::<Signal<Vec<String>>>()
+//         .expect("should find army_ids in context")
+//         .get();
+//     ids.remove(ids.iter().position(|x| *x == army_id)
+//                .expect("id should be in the list to remove it"));
+//     let remove_army_url = if ids.is_empty() {
+//         "./".to_string()
+//     } else {
+//         format!("./?armies={}", ids.join(","))
+//     };
 
-    view! {
-        <a href=remove_army_url >
-            <button class="rm_army">
-                <ltn::Icon icon=ltn::icondata::IoCloseCircleOutline />
-            </button>
-        </a>
-    }
-}
+//     view! {
+//         <a href=remove_army_url >
+//             <button class="rm_army">
+//                 <ltn::Icon icon=ltn::icondata::IoCloseCircleOutline />
+//             </button>
+//         </a>
+//     }
+// }
 
-#[component]
-fn DetailsDrawer(army: Army,
-                 side: ltn::DrawerSide) -> impl IntoView {
-    let pos_class = match side {
-        ltn::DrawerSide::Left => "left",
-        ltn::DrawerSide::Right => "right",
-    };
+// #[component]
+// fn DetailsDrawer(army: Army,
+//                  side: ltn::DrawerSide) -> impl IntoView {
+//     let pos_class = match side {
+//         ltn::DrawerSide::Left => "left",
+//         ltn::DrawerSide::Right => "right",
+//     };
 
-    let shown = use_context::<DrawerControl>().unwrap().shown;
-    view! {
-        <ltn::Drawer side shown class={format!("army_details {pos_class}")}>
-            <Show when=move || shown.get() >
-                <GroupDetails army=army.clone() side
-                              group=army.unit_selection.get().unwrap() />
-            </Show>
-        </ltn::Drawer>
-    }
-}
+//     let shown = use_context::<DrawerControl>().unwrap().shown;
+//     view! {
+//         <ltn::Drawer side shown class={format!("army_details {pos_class}")}>
+//             <Show when=move || shown.get() >
+//                 <GroupDetails army=army.clone() side
+//                               group=army.unit_selection.get().unwrap() />
+//             </Show>
+//         </ltn::Drawer>
+//     }
+// }
 
-#[component]
-fn GroupDetails(group: Rc<opr::UnitGroup>,
-                army: Army,
-                side: ltn::DrawerSide,
-) -> impl IntoView
-{
-    let opr::UnitGroup{full_cost, ..} = *group;
-    let shown = use_context::<DrawerControl>().unwrap().shown;
-    let group_name = group.formatted_name();
-    let close_button = |glyph| view! {
-        <ltn::Button color=ltn::ButtonColor::Secondary
-                     on_click=move |_| shown.set(false)> {glyph} </ltn::Button>
-    };
-    let (left_button, right_button) = match side {
-        ltn::DrawerSide::Left  => ( Some(close_button("<")), None ),
-        ltn::DrawerSide::Right => ( None, Some(close_button(">")) ),
-    };
+// #[component]
+// fn GroupDetails(group: Rc<opr::UnitGroup>,
+//                 army: Army,
+//                 side: ltn::DrawerSide,
+// ) -> impl IntoView
+// {
+//     let opr::UnitGroup{full_cost, ..} = *group;
+//     let shown = use_context::<DrawerControl>().unwrap().shown;
+//     let group_name = group.formatted_name();
+//     let close_button = |glyph| view! {
+//         <ltn::Button color=ltn::ButtonColor::Secondary
+//                      on_click=move |_| shown.set(false)> {glyph} </ltn::Button>
+//     };
+//     let (left_button, right_button) = match side {
+//         ltn::DrawerSide::Left  => ( Some(close_button("<")), None ),
+//         ltn::DrawerSide::Right => ( None, Some(close_button(">")) ),
+//     };
 
-    view! {
-        <h3>
-            <ltn::Stack orientation=ltn::StackOrientation::Horizontal
-                        style="width: 100%; justify-content: space-between;"
-                        spacing=ltn::Size::Em(0.0)>
-                <ltn::Stack orientation=ltn::StackOrientation::Horizontal
-                            spacing=ltn::Size::Em(1.0)>
-                    {left_button}
-                    {group_name}
-                </ltn::Stack>
-                <ltn::Stack orientation=ltn::StackOrientation::Horizontal
-                            spacing=ltn::Size::Em(1.0)>
-                    {format!("{full_cost} pts")}
-                    {right_button}
-                </ltn::Stack>
-            </ltn::Stack>
-        </h3>
+//     view! {
+//         <h3>
+//             <ltn::Stack orientation=ltn::StackOrientation::Horizontal
+//                         style="width: 100%; justify-content: space-between;"
+//                         spacing=ltn::Size::Em(0.0)>
+//                 <ltn::Stack orientation=ltn::StackOrientation::Horizontal
+//                             spacing=ltn::Size::Em(1.0)>
+//                     {left_button}
+//                     {group_name}
+//                 </ltn::Stack>
+//                 <ltn::Stack orientation=ltn::StackOrientation::Horizontal
+//                             spacing=ltn::Size::Em(1.0)>
+//                     {format!("{full_cost} pts")}
+//                     {right_button}
+//                 </ltn::Stack>
+//             </ltn::Stack>
+//         </h3>
 
-        {
-            let single = group.units.len() == 1;
-            group.units.iter()
-                .map(|unit| view! {<UnitDetails unit=Rc::clone(unit) single />})
-                .collect_view()
-        }
+//         {
+//             let single = group.units.len() == 1;
+//             group.units.iter()
+//                 .map(|unit| view! {<UnitDetails unit=Rc::clone(unit) single />})
+//                 .collect_view()
+//         }
 
-        <SpecialRulesDefList group=Rc::clone(&group) army />
-    }
-}
+//         <SpecialRulesDefList group=Rc::clone(&group) army />
+//     }
+// }
 
-#[component]
-fn UnitDetails(unit: Rc<opr::Unit>,
-               single: bool,
-) -> impl IntoView
-{
-    let unit_name = unit.formatted_name();
-    let opr::Unit{quality, defense, full_cost, ref loadout, ref special_rules, ..} = *unit;
-    let special_rules = special_rules.clone();
+// #[component]
+// fn UnitDetails(unit: Rc<opr::Unit>,
+//                single: bool,
+// ) -> impl IntoView
+// {
+//     let unit_name = unit.formatted_name();
+//     let opr::Unit{quality, defense, full_cost, ref loadout, ref special_rules, ..} = *unit;
+//     let special_rules = special_rules.clone();
 
-    view! {
-        <p>
-            <ltn::Stack orientation=ltn::StackOrientation::Horizontal
-                        style="width: 100%; justify-content: space-between;"
-                        spacing=ltn::Size::Em(0.0)>
-                <span>
-                    <span class="unit">
-                        {(!single).then(|| format!("{unit_name}: "))}
-                        {format!("Q{quality} D{defense}")}
-                    </span>
-                    " "
-                    <SpecialRulesList special_rules={special_rules.clone()} />
-                </span>
-                {format!("{full_cost} pts")}
-            </ltn::Stack>
-        </p>
-        <p><UnitUpgradesList loadout_list={loadout.clone()} /></p>
-        <EquipmentList loadout_list={loadout.clone()} />
-    }
-}
+//     view! {
+//         <p>
+//             <ltn::Stack orientation=ltn::StackOrientation::Horizontal
+//                         style="width: 100%; justify-content: space-between;"
+//                         spacing=ltn::Size::Em(0.0)>
+//                 <span>
+//                     <span class="unit">
+//                         {(!single).then(|| format!("{unit_name}: "))}
+//                         {format!("Q{quality} D{defense}")}
+//                     </span>
+//                     " "
+//                     <SpecialRulesList special_rules={special_rules.clone()} />
+//                 </span>
+//                 {format!("{full_cost} pts")}
+//             </ltn::Stack>
+//         </p>
+//         <p><UnitUpgradesList loadout_list={loadout.clone()} /></p>
+//         <EquipmentList loadout_list={loadout.clone()} />
+//     }
+// }
 
-#[component]
-fn UnitUpgradesList(loadout_list: Vec<Rc<opr::UnitLoadout>>) -> impl IntoView {
-    view! {
-        {move || {
-            loadout_list
-                .clone()
-                .into_iter()
-                .filter(|loadout| matches!(**loadout, opr::UnitLoadout::Upgrade{..}))
-                .enumerate()
-                .map(|(i, loadout)| {
-                    if let opr::UnitLoadout::Upgrade(ref upgrade) = *loadout {
-                        let opr::UnitUpgrade{name, ref content, ..} = upgrade;
-                        view! {
-                            {move || if i > 0 { ", " } else { "" }}
-                            {Rc::clone(name)} " (" <SpecialRulesList special_rules={content.clone()} /> ")"
-                        }
-                    } else {
-                        panic!();
-                    }
-                })
-                .collect_view()
-        }}
-    }
-}
+// #[component]
+// fn UnitUpgradesList(loadout_list: Vec<Rc<opr::UnitLoadout>>) -> impl IntoView {
+//     view! {
+//         {move || {
+//             loadout_list
+//                 .clone()
+//                 .into_iter()
+//                 .filter(|loadout| matches!(**loadout, opr::UnitLoadout::Upgrade{..}))
+//                 .enumerate()
+//                 .map(|(i, loadout)| {
+//                     if let opr::UnitLoadout::Upgrade(ref upgrade) = *loadout {
+//                         let opr::UnitUpgrade{name, ref content, ..} = upgrade;
+//                         view! {
+//                             {move || if i > 0 { ", " } else { "" }}
+//                             {Rc::clone(name)} " (" <SpecialRulesList special_rules={content.clone()} /> ")"
+//                         }
+//                     } else {
+//                         panic!();
+//                     }
+//                 })
+//                 .collect_view()
+//         }}
+//     }
+// }
 
-#[component]
-fn EquipmentList(loadout_list: Vec<Rc<opr::UnitLoadout>>) -> impl IntoView {
-    view! {
-        <ltn::TableContainer>
-            <ltn::Table bordered=true hoverable=true>
-                <ltn::TableBody>
-                    {move || {
-                        loadout_list
-                            .clone()
-                            .into_iter()
-                            .filter(|loadout| matches!(**loadout, opr::UnitLoadout::Equipment{..}))
-                            .map(|loadout| {
-                                view! {
-                                    <EquipmentItem loadout />
-                                }
-                            })
-                            .collect_view()
-                    }}
-                </ltn::TableBody>
-            </ltn::Table>
-        </ltn::TableContainer>
-    }
-}
+// #[component]
+// fn EquipmentList(loadout_list: Vec<Rc<opr::UnitLoadout>>) -> impl IntoView {
+//     view! {
+//         <ltn::TableContainer>
+//             <ltn::Table bordered=true hoverable=true>
+//                 <ltn::TableBody>
+//                     {move || {
+//                         loadout_list
+//                             .clone()
+//                             .into_iter()
+//                             .filter(|loadout| matches!(**loadout, opr::UnitLoadout::Equipment{..}))
+//                             .map(|loadout| {
+//                                 view! {
+//                                     <EquipmentItem loadout />
+//                                 }
+//                             })
+//                             .collect_view()
+//                     }}
+//                 </ltn::TableBody>
+//             </ltn::Table>
+//         </ltn::TableContainer>
+//     }
+// }
 
-#[component]
-fn EquipmentItem(loadout: Rc<opr::UnitLoadout>) -> impl IntoView {
-    if let opr::UnitLoadout::Equipment(ref equipment) = *loadout {
-        let name = Rc::clone(&equipment.name);
-        let special_rules = equipment.special_rules.clone();
-        let opr::Equipment{count, range, attacks, ..} = *equipment;
-        view! {
-            <ltn::TableRow>
-                <ltn::TableCell>
-                    {if count != 1
-                        {format!("{}x ", count)} else {"".to_string()}}
-                    {name}
-                </ltn::TableCell>
-                <ltn::TableCell>
-                    {if range != 0
-                        {format!(r#"{}""#, range )}
-                        else {"-".to_string()}}
-                </ltn::TableCell>
-                <ltn::TableCell>
-                    {format!("A{}", attacks)}
-                </ltn::TableCell>
-                <ltn::TableCell>
-                    <SpecialRulesList special_rules={special_rules.clone()} />
-                </ltn::TableCell>
-            </ltn::TableRow>
-        }
-    } else {
-        panic!("EquipmentItem must be used on Equipment only");
-    }
-}
+// #[component]
+// fn EquipmentItem(loadout: Rc<opr::UnitLoadout>) -> impl IntoView {
+//     if let opr::UnitLoadout::Equipment(ref equipment) = *loadout {
+//         let name = Rc::clone(&equipment.name);
+//         let special_rules = equipment.special_rules.clone();
+//         let opr::Equipment{count, range, attacks, ..} = *equipment;
+//         view! {
+//             <ltn::TableRow>
+//                 <ltn::TableCell>
+//                     {if count != 1
+//                         {format!("{}x ", count)} else {"".to_string()}}
+//                     {name}
+//                 </ltn::TableCell>
+//                 <ltn::TableCell>
+//                     {if range != 0
+//                         {format!(r#"{}""#, range )}
+//                         else {"-".to_string()}}
+//                 </ltn::TableCell>
+//                 <ltn::TableCell>
+//                     {format!("A{}", attacks)}
+//                 </ltn::TableCell>
+//                 <ltn::TableCell>
+//                     <SpecialRulesList special_rules={special_rules.clone()} />
+//                 </ltn::TableCell>
+//             </ltn::TableRow>
+//         }
+//     } else {
+//         panic!("EquipmentItem must be used on Equipment only");
+//     }
+// }
 
-#[component]
-fn SpecialRulesList(special_rules: Vec<Rc<opr::SpecialRule>>) -> impl IntoView {
-    special_rules.iter()
-    // render each rule
-        .enumerate()
-        .map(|(i, special_rule)| {
-            let separator = if i == 0 { "" } else { ", " };
-            let rating = match special_rule.rating {
-                None => { "".to_string() },
-                Some(rating) => { format!("({})", rating) },
-            };
-            view! {
-                {separator}
-                <special-rule>
-                    {Rc::clone(&special_rule.name)}
-                </special-rule>
-                {rating}
-            }
-        })
-        .collect_view()
-}
+// #[component]
+// fn SpecialRulesList(special_rules: Vec<Rc<opr::SpecialRule>>) -> impl IntoView {
+//     special_rules.iter()
+//     // render each rule
+//         .enumerate()
+//         .map(|(i, special_rule)| {
+//             let separator = if i == 0 { "" } else { ", " };
+//             let rating = match special_rule.rating {
+//                 None => { "".to_string() },
+//                 Some(rating) => { format!("({})", rating) },
+//             };
+//             view! {
+//                 {separator}
+//                 <special-rule>
+//                     {Rc::clone(&special_rule.name)}
+//                 </special-rule>
+//                 {rating}
+//             }
+//         })
+//         .collect_view()
+// }
 
-#[component]
-fn SpecialRulesDefList(group: Rc<opr::UnitGroup>,
-                       army: Army,) -> impl IntoView {
-    view! {
-        <specialrules-def-list>
-            {move || {
-                let group = Rc::clone(&group);
-                army.army_data.with(
-                    move |army_data| {
-                        if let Some(Ok(army_data)) = army_data {
-                            // the rules def
-                            let opr::Army{ref special_rules, ..} = **army_data;
-                            let special_rules_def = special_rules;
+// #[component]
+// fn SpecialRulesDefList(group: Rc<opr::UnitGroup>,
+//                        army: Army,) -> impl IntoView {
+//     view! {
+//         <specialrules-def-list>
+//             {move || {
+//                 let group = Rc::clone(&group);
+//                 army.army_data.with(
+//                     move |army_data| {
+//                         if let Some(Ok(army_data)) = army_data {
+//                             // the rules def
+//                             let opr::Army{ref special_rules, ..} = **army_data;
+//                             let special_rules_def = special_rules;
 
-                            view!{
-                                {match common_rules_def() {
-                                    Ok(common_rules_def) => view! {
-                                        {rules_descriptions_from_list_for_group(
-                                            Rc::clone(&group), &common_rules_def.clone())}
-                                    }.into_view(),
-                                    Err(message) => view! {
-                                        <ltn::Alert variant=ltn::AlertVariant::Danger>
-                                            <AlertContent slot>{message}</AlertContent>
-                                        </ltn::Alert>
-                                    }.into_view(),
-                                }}
-                                {rules_descriptions_from_list_for_group(
-                                    Rc::clone(&group), special_rules_def)}
-                            }.into_view()
-                        } else {
-                            // cannot happen - FIXME should pass opr::Army directly instead?
-                            view!{}.into_view()
-                        }
-                    }
-                )
-            }}
-        </specialrules-def-list>
-    }
-}
+//                             view!{
+//                                 {match common_rules_def() {
+//                                     Ok(common_rules_def) => view! {
+//                                         {rules_descriptions_from_list_for_group(
+//                                             Rc::clone(&group), &common_rules_def.clone())}
+//                                     }.into_view(),
+//                                     Err(message) => view! {
+//                                         <ltn::Alert variant=ltn::AlertVariant::Danger>
+//                                             <AlertContent slot>{message}</AlertContent>
+//                                         </ltn::Alert>
+//                                     }.into_view(),
+//                                 }}
+//                                 {rules_descriptions_from_list_for_group(
+//                                     Rc::clone(&group), special_rules_def)}
+//                             }.into_view()
+//                         } else {
+//                             // cannot happen - FIXME should pass opr::Army directly instead?
+//                             view!{}.into_view()
+//                         }
+//                     }
+//                 )
+//             }}
+//         </specialrules-def-list>
+//     }
+// }
 
 /// extract common-rules definitions from the Context Resource, or an
 /// error string to display

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,7 +167,7 @@ fn App() -> impl IntoView {
                               <SelectView alert_type={thaw::MessageBarIntent::Info}
                                           message="no army selected".to_string() />
                           } >
-                        "Armies" // <ArmiesView army_ids=Signal::derive(move || army_ids.get().unwrap().clone()) />
+                        <ArmiesView army_ids=Signal::derive(move || army_ids.get().unwrap().clone()) />
                     </Show>
                 </Show>
             </thaw::Flex>
@@ -234,27 +234,27 @@ fn SampleMatchups() -> impl IntoView {
     }
 }
 
-// /// the main view, showing multiple armies and providing detail
-// /// drawers for selections
-// #[component]
-// fn ArmiesView(army_ids: Signal<Vec<String>>) -> impl IntoView {
-//     provide_context(army_ids);
-//     view! {
-//         <Title text="view armies" />
-//         <thaw::Flex class="army_view" >
-//             <For each=move || army_ids.with(|ids| ids.iter()
-//                                             .map(String::clone)
-//                                             .enumerate().collect::<Vec<(usize, String)>>())
-//                  key=|k: &(usize, String)| k.clone()
-//                  children=move |(i, id)| view! {
-//                      <ArmyContainer army={Army::new(Signal::derive(move || id.clone()))}
-//                                     side={if i == 0 {thaw::DrawerPlacement::Left}
-//                                           else {thaw::DrawerPlacement::Right}} />
-//                  }
-//              />
-//         </thaw::Flex>
-//     }
-// }
+/// the main view, showing multiple armies and providing detail
+/// drawers for selections
+#[component]
+fn ArmiesView(army_ids: Signal<Vec<String>>) -> impl IntoView {
+    provide_context(army_ids);
+    view! {
+        <Title text="view armies" />
+        <thaw::Flex class="army_view" >
+            <For each=move || army_ids.with(|ids| ids.iter()
+                                            .map(String::clone)
+                                            .enumerate().collect::<Vec<(usize, String)>>())
+                 key=|k: &(usize, String)| k.clone()
+                 children=move |(i, id)| view! {
+                     "Army" //<ArmyContainer army={Army::new(Signal::derive(move || id.clone()))}
+                            //       side={if i == 0 {thaw::DrawerPlacement::Left}
+                            //             else {thaw::DrawerPlacement::Right}} />
+                 }
+             />
+        </thaw::Flex>
+    }
+}
 
 // #[derive(Clone)]
 // struct DrawerControl {

--- a/src/main.rs
+++ b/src/main.rs
@@ -467,46 +467,44 @@ fn GroupDetails(group: Rc<opr::UnitGroup>,
             </thaw::Space>
         </h3>
 
-        // {
-        //     let single = group.units.len() == 1;
-        //     group.units.iter()
-        //         .map(|unit| view! {<UnitDetails unit=Rc::clone(unit) single />})
-        //         .collect_view()
-        // }
+        {
+            let single = group.units.len() == 1;
+            group.units.iter()
+                .map(|unit| view! {<UnitDetails unit=Rc::clone(unit) single />})
+                .collect_view()
+        }
 
         // <SpecialRulesDefList group=Rc::clone(&group) army />
     }
 }
 
-// #[component]
-// fn UnitDetails(unit: Rc<opr::Unit>,
-//                single: bool,
-// ) -> impl IntoView
-// {
-//     let unit_name = unit.formatted_name();
-//     let opr::Unit{quality, defense, full_cost, ref loadout, ref special_rules, ..} = *unit;
-//     let special_rules = special_rules.clone();
+#[component]
+fn UnitDetails(unit: Rc<opr::Unit>,
+               single: bool,
+) -> impl IntoView
+{
+    let unit_name = unit.formatted_name();
+    let opr::Unit{quality, defense, full_cost, ref loadout, ref special_rules, ..} = *unit;
+    let special_rules = special_rules.clone();
 
-//     view! {
-//         <p>
-//             <ltn::Stack orientation=ltn::StackOrientation::Horizontal
-//                         style="width: 100%; justify-content: space-between;"
-//                         spacing=ltn::Size::Em(0.0)>
-//                 <span>
-//                     <span class="unit">
-//                         {(!single).then(|| format!("{unit_name}: "))}
-//                         {format!("Q{quality} D{defense}")}
-//                     </span>
-//                     " "
-//                     <SpecialRulesList special_rules={special_rules.clone()} />
-//                 </span>
-//                 {format!("{full_cost} pts")}
-//             </ltn::Stack>
-//         </p>
-//         <p><UnitUpgradesList loadout_list={loadout.clone()} /></p>
-//         <EquipmentList loadout_list={loadout.clone()} />
-//     }
-// }
+    view! {
+        <p>
+            <thaw::Space justify=thaw::SpaceJustify::SpaceBetween>
+                <span>
+                    <span class="unit">
+                        {(!single).then(|| format!("{unit_name}: "))}
+                        {format!("Q{quality} D{defense}")}
+                    </span>
+                    " "
+//                    <SpecialRulesList special_rules={special_rules.clone()} />
+                </span>
+                {format!("{full_cost} pts")}
+            </thaw::Space>
+        </p>
+//        <p><UnitUpgradesList loadout_list={loadout.clone()} /></p>
+//        <EquipmentList loadout_list={loadout.clone()} />
+    }
+}
 
 // #[component]
 // fn UnitUpgradesList(loadout_list: Vec<Rc<opr::UnitLoadout>>) -> impl IntoView {

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,8 @@ fn App() -> impl IntoView {
         })
     });
     view! {
-        <thaw::Layout class="app">
+        <thaw::Layout class="app"
+                      content_style="min-height: 100vh; display: flex; flex-direction: column">
             <thaw::LayoutHeader class="app-bar">
                 <thaw::Flex justify=thaw::FlexJustify::SpaceBetween align=thaw::FlexAlign::Center>
                     <h1>
@@ -154,7 +155,8 @@ fn App() -> impl IntoView {
                     <ThemeToggle/>
                 </thaw::Flex>
             </thaw::LayoutHeader>
-            <thaw::Flex class="app-contents" justify=thaw::FlexJustify::Center>
+            <thaw::Flex class="app-contents" justify=thaw::FlexJustify::Center
+                        style="flex: 1">
                 <Show when=move || { army_ids.with(Result::is_ok) }
                       fallback=move || view! {
                           // <SelectView alert_type={thaw::AlertVariant::Warning}

--- a/src/main.rs
+++ b/src/main.rs
@@ -531,7 +531,7 @@ fn UnitDetails(unit: Arc<opr::Unit>,
                         {format!("Q{quality} D{defense}")}
                     </span>
                     " "
-                    // <SpecialRulesList special_rules={special_rules.clone()} />
+                    <SpecialRulesList special_rules={special_rules.clone()} />
                 </span>
                 {format!("{full_cost} pts")}
             </thaw::Space>
@@ -555,8 +555,8 @@ fn UnitUpgradesList(loadout_list: Vec<Arc<opr::UnitLoadout>>) -> impl IntoView {
                         let opr::UnitUpgrade{name, ref content, ..} = upgrade;
                         view! {
                             {move || if i > 0 { ", " } else { "" }}
-                            {Arc::clone(name)} " (" //<SpecialRulesList special_rules={content.clone()} />
-                                ")"
+                            {Arc::clone(name)}
+                            " (" <SpecialRulesList special_rules={content.clone()} /> ")"
                         }
                     } else {
                         panic!();
@@ -613,7 +613,7 @@ fn EquipmentItem(loadout: Arc<opr::UnitLoadout>) -> impl IntoView {
                     {format!("A{}", attacks)}
                 </td>
                 <td>
-                    // <SpecialRulesList special_rules={special_rules.clone()} />
+                    <SpecialRulesList special_rules={special_rules.clone()} />
                 </td>
             </tr>
         }
@@ -622,27 +622,27 @@ fn EquipmentItem(loadout: Arc<opr::UnitLoadout>) -> impl IntoView {
     }
 }
 
-// #[component]
-// fn SpecialRulesList(special_rules: Vec<Arc<opr::SpecialRule>>) -> impl IntoView {
-//     special_rules.iter()
-//     // render each rule
-//         .enumerate()
-//         .map(|(i, special_rule)| {
-//             let separator = if i == 0 { "" } else { ", " };
-//             let rating = match special_rule.rating {
-//                 None => { "".to_string() },
-//                 Some(rating) => { format!("({})", rating) },
-//             };
-//             view! {
-//                 {separator}
-//                 <special-rule>
-//                     {Arc::clone(&special_rule.name)}
-//                 </special-rule>
-//                 {rating}
-//             }
-//         })
-//         .collect_view()
-// }
+#[component]
+fn SpecialRulesList(special_rules: Vec<Arc<opr::SpecialRule>>) -> impl IntoView {
+    special_rules.iter()
+    // render each rule
+        .enumerate()
+        .map(|(i, special_rule)| {
+            let separator = if i == 0 { "" } else { ", " };
+            let rating = match special_rule.rating {
+                None => { "".to_string() },
+                Some(rating) => { format!("({})", rating) },
+            };
+            view! {
+                {separator}
+                <special-rule>
+                    {Arc::clone(&special_rule.name)}
+                </special-rule>
+                {rating}
+            }
+        })
+        .collect_view()
+}
 
 // #[component]
 // fn SpecialRulesDefList(group: Arc<opr::UnitGroup>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -501,35 +501,36 @@ fn UnitDetails(unit: Rc<opr::Unit>,
                 {format!("{full_cost} pts")}
             </thaw::Space>
         </p>
-//        <p><UnitUpgradesList loadout_list={loadout.clone()} /></p>
+        <p><UnitUpgradesList loadout_list={loadout.clone()} /></p>
 //        <EquipmentList loadout_list={loadout.clone()} />
     }
 }
 
-// #[component]
-// fn UnitUpgradesList(loadout_list: Vec<Rc<opr::UnitLoadout>>) -> impl IntoView {
-//     view! {
-//         {move || {
-//             loadout_list
-//                 .clone()
-//                 .into_iter()
-//                 .filter(|loadout| matches!(**loadout, opr::UnitLoadout::Upgrade{..}))
-//                 .enumerate()
-//                 .map(|(i, loadout)| {
-//                     if let opr::UnitLoadout::Upgrade(ref upgrade) = *loadout {
-//                         let opr::UnitUpgrade{name, ref content, ..} = upgrade;
-//                         view! {
-//                             {move || if i > 0 { ", " } else { "" }}
-//                             {Rc::clone(name)} " (" <SpecialRulesList special_rules={content.clone()} /> ")"
-//                         }
-//                     } else {
-//                         panic!();
-//                     }
-//                 })
-//                 .collect_view()
-//         }}
-//     }
-// }
+#[component]
+fn UnitUpgradesList(loadout_list: Vec<Rc<opr::UnitLoadout>>) -> impl IntoView {
+    view! {
+        {move || {
+            loadout_list
+                .clone()
+                .into_iter()
+                .filter(|loadout| matches!(**loadout, opr::UnitLoadout::Upgrade{..}))
+                .enumerate()
+                .map(|(i, loadout)| {
+                    if let opr::UnitLoadout::Upgrade(ref upgrade) = *loadout {
+                        let opr::UnitUpgrade{name, ref content, ..} = upgrade;
+                        view! {
+                            {move || if i > 0 { ", " } else { "" }}
+                            {Rc::clone(name)} " (" // <SpecialRulesList special_rules={content.clone()} />
+                                ")"
+                        }
+                    } else {
+                        panic!();
+                    }
+                })
+                .collect_view()
+        }}
+    }
+}
 
 // #[component]
 // fn EquipmentList(loadout_list: Vec<Rc<opr::UnitLoadout>>) -> impl IntoView {

--- a/src/main.rs
+++ b/src/main.rs
@@ -427,59 +427,56 @@ fn DetailsDrawer(army: Army,
         <thaw::Drawer placement=side show=shown modal_type=thaw::DrawerModalType::NonModal
                       class={format!("army_details {pos_class} color-scheme--light")}>
             <Show when=move || shown.get() >
-                "GroupDetails" // <GroupDetails army=army.clone() placement
-                //               group=army.unit_selection.get().unwrap() />
+                <GroupDetails army=army.clone() side
+                              group=army.unit_selection.get().unwrap() />
             </Show>
         </thaw::Drawer>
     }
 }
 
-// #[component]
-// fn GroupDetails(group: Rc<opr::UnitGroup>,
-//                 army: Army,
-//                 side: ltn::DrawerSide,
-// ) -> impl IntoView
-// {
-//     let opr::UnitGroup{full_cost, ..} = *group;
-//     let shown = use_context::<DrawerControl>().unwrap().shown;
-//     let group_name = group.formatted_name();
-//     let close_button = |glyph| view! {
-//         <ltn::Button color=ltn::ButtonColor::Secondary
-//                      on_click=move |_| shown.set(false)> {glyph} </ltn::Button>
-//     };
-//     let (left_button, right_button) = match side {
-//         ltn::DrawerSide::Left  => ( Some(close_button("<")), None ),
-//         ltn::DrawerSide::Right => ( None, Some(close_button(">")) ),
-//     };
+#[component]
+fn GroupDetails(group: Rc<opr::UnitGroup>,
+                army: Army,
+                side: thaw::DrawerPlacement,
+) -> impl IntoView
+{
+    let opr::UnitGroup{full_cost, ..} = *group;
+    let shown = use_context::<DrawerControl>().unwrap().shown;
+    let group_name = group.formatted_name();
+    let close_button = |glyph| view! {
+        <thaw::Button //color=ltn::ButtonColor::Secondary
+                      on_click=move |_| shown.set(false)> {glyph} </thaw::Button>
+    };
+    let (left_button, right_button) = match side {
+        thaw::DrawerPlacement::Left  => ( Some(close_button("<")), None ),
+        thaw::DrawerPlacement::Right => ( None, Some(close_button(">")) ),
+        _ => unreachable!(),
+    };
 
-//     view! {
-//         <h3>
-//             <ltn::Stack orientation=ltn::StackOrientation::Horizontal
-//                         style="width: 100%; justify-content: space-between;"
-//                         spacing=ltn::Size::Em(0.0)>
-//                 <ltn::Stack orientation=ltn::StackOrientation::Horizontal
-//                             spacing=ltn::Size::Em(1.0)>
-//                     {left_button}
-//                     {group_name}
-//                 </ltn::Stack>
-//                 <ltn::Stack orientation=ltn::StackOrientation::Horizontal
-//                             spacing=ltn::Size::Em(1.0)>
-//                     {format!("{full_cost} pts")}
-//                     {right_button}
-//                 </ltn::Stack>
-//             </ltn::Stack>
-//         </h3>
+    view! {
+        <h3>
+            <thaw::Space justify=thaw::SpaceJustify::SpaceBetween >
+                <thaw::Space>
+                    {left_button}
+                    {group_name}
+                </thaw::Space>
+                <thaw::Space>
+                    {format!("{full_cost} pts")}
+                    {right_button}
+                </thaw::Space>
+            </thaw::Space>
+        </h3>
 
-//         {
-//             let single = group.units.len() == 1;
-//             group.units.iter()
-//                 .map(|unit| view! {<UnitDetails unit=Rc::clone(unit) single />})
-//                 .collect_view()
-//         }
+        // {
+        //     let single = group.units.len() == 1;
+        //     group.units.iter()
+        //         .map(|unit| view! {<UnitDetails unit=Rc::clone(unit) single />})
+        //         .collect_view()
+        // }
 
-//         <SpecialRulesDefList group=Rc::clone(&group) army />
-//     }
-// }
+        // <SpecialRulesDefList group=Rc::clone(&group) army />
+    }
+}
 
 // #[component]
 // fn UnitDetails(unit: Rc<opr::Unit>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -537,7 +537,7 @@ fn UnitDetails(unit: Arc<opr::Unit>,
             </thaw::Space>
         </p>
         <p><UnitUpgradesList loadout_list={loadout.clone()} /></p>
-        // <EquipmentList loadout_list={loadout.clone()} />
+        <EquipmentList loadout_list={loadout.clone()} />
     }
 }
 
@@ -567,60 +567,60 @@ fn UnitUpgradesList(loadout_list: Vec<Arc<opr::UnitLoadout>>) -> impl IntoView {
     }
 }
 
-// #[component]
-// fn EquipmentList(loadout_list: Vec<Arc<opr::UnitLoadout>>) -> impl IntoView {
-//     view! {
-//         <table-wrapper>
-//             <table bordered=true hoverable=true>
-//                 <tbody>
-//                     {move || {
-//                         loadout_list
-//                             .clone()
-//                             .into_iter()
-//                             .filter(|loadout| matches!(**loadout, opr::UnitLoadout::Equipment{..}))
-//                             .map(|loadout| {
-//                                 view! {
-//                                     <EquipmentItem loadout />
-//                                 }
-//                             })
-//                             .collect_view()
-//                     }}
-//                 </tbody>
-//             </table>
-//         </table-wrapper>
-//     }
-// }
+#[component]
+fn EquipmentList(loadout_list: Vec<Arc<opr::UnitLoadout>>) -> impl IntoView {
+    view! {
+        <table-wrapper>
+            <table> // FIXME bordered=true hoverable=true>
+                <tbody>
+                    {move || {
+                        loadout_list
+                            .clone()
+                            .into_iter()
+                            .filter(|loadout| matches!(**loadout, opr::UnitLoadout::Equipment{..}))
+                            .map(|loadout| {
+                                view! {
+                                    <EquipmentItem loadout />
+                                }
+                            })
+                            .collect_view()
+                    }}
+                </tbody>
+            </table>
+        </table-wrapper>
+    }
+}
 
-// #[component]
-// fn EquipmentItem(loadout: Arc<opr::UnitLoadout>) -> impl IntoView {
-//     if let opr::UnitLoadout::Equipment(ref equipment) = *loadout {
-//         let name = Arc::clone(&equipment.name);
-//         let special_rules = equipment.special_rules.clone();
-//         let opr::Equipment{count, range, attacks, ..} = *equipment;
-//         view! {
-//             <tr>
-//                 <td>
-//                     {if count != 1
-//                         {format!("{}x ", count)} else {"".to_string()}}
-//                     {name}
-//                 </td>
-//                 <td>
-//                     {if range != 0
-//                         {format!(r#"{}""#, range )}
-//                         else {"-".to_string()}}
-//                 </td>
-//                 <td>
-//                     {format!("A{}", attacks)}
-//                 </td>
-//                 <td>
-//                     <SpecialRulesList special_rules={special_rules.clone()} />
-//                 </td>
-//             </tr>
-//         }
-//     } else {
-//         panic!("EquipmentItem must be used on Equipment only");
-//     }
-// }
+#[component]
+fn EquipmentItem(loadout: Arc<opr::UnitLoadout>) -> impl IntoView {
+    if let opr::UnitLoadout::Equipment(ref equipment) = *loadout {
+        let name = Arc::clone(&equipment.name);
+        let special_rules = equipment.special_rules.clone();
+        let opr::Equipment{count, range, attacks, ..} = *equipment;
+        view! {
+            <tr>
+                <td>
+                    {if count != 1
+                        {format!("{}x ", count)} else {"".to_string()}}
+                    {name}
+                </td>
+                <td>
+                    {if range != 0
+                        {format!(r#"{}""#, range )}
+                        else {"-".to_string()}}
+                </td>
+                <td>
+                    {format!("A{}", attacks)}
+                </td>
+                <td>
+                    // <SpecialRulesList special_rules={special_rules.clone()} />
+                </td>
+            </tr>
+        }
+    } else {
+        panic!("EquipmentItem must be used on Equipment only");
+    }
+}
 
 // #[component]
 // fn SpecialRulesList(special_rules: Vec<Arc<opr::SpecialRule>>) -> impl IntoView {

--- a/src/main.rs
+++ b/src/main.rs
@@ -361,8 +361,8 @@ fn ArmyList(army: Army,
                                 let check_inconsistency = check_inconsistency();
                                 if check_inconsistency.is_none() {
                                     Either::Left(view! {
-                                        // <UnitsList unit_groups={unit_groups.clone()}
-                                        //            select_unit=army.unit_selection />
+                                        <UnitsList unit_groups={unit_groups.clone()}
+                                                   select_unit=army.unit_selection />
                                     })
                                 } else {
                                     Either::Right(view! {
@@ -383,44 +383,44 @@ fn ArmyList(army: Army,
     }
 }
 
-// #[component]
-// fn UnitsList(unit_groups: Vec<Arc<opr::UnitGroup>>,
-//              select_unit: RwSignal<Option<Arc<opr::UnitGroup>>>, // FIXME only need WriteSignal here
-// ) -> impl IntoView {
-//     let (selected_row_num, set_selected_row_num) = create_signal(None::<usize>);
-//     view! {
-//         <table-wrapper>
-//             <table bordered=true hoverable=true>
-//                 <tbody>
-//                     {move || {
-//                         unit_groups
-//                             .clone()
-//                             .into_iter()
-//                             .enumerate()
-//                             .map(|(i, group)| {
-//                                 let group_name = (*group).formatted_name();
-//                                 //let opr::Unit{..} = *unit;
-//                                 view! {
-//                                     <tr
-//                                          class:selected=move || {
-//                                              matches!(selected_row_num.get(),
-//                                                       Some(index) if index == i)
-//                                          }
-//                                          on:click=move |_| {
-//                                              select_unit.set(Some(group.clone()));
-//                                              set_selected_row_num.set(Some(i));
-//                                     }>
-//                                         <td> {group_name} </td>
-//                                     </tr>
-//                                 }
-//                             })
-//                             .collect_view()
-//                     }}
-//                 </tbody>
-//             </table>
-//         </table-wrapper>
-//     }
-// }
+#[component]
+fn UnitsList(unit_groups: Vec<Arc<opr::UnitGroup>>,
+             select_unit: RwSignal<Option<Arc<opr::UnitGroup>>>, // FIXME only need WriteSignal here
+) -> impl IntoView {
+    let (selected_row_num, set_selected_row_num) = signal(None::<usize>);
+    view! {
+        <table-wrapper>
+            <table> // FIXME bordered=true hoverable=true>
+                <tbody>
+                    {move || {
+                        unit_groups
+                            .clone()
+                            .into_iter()
+                            .enumerate()
+                            .map(|(i, group)| {
+                                let group_name = (*group).formatted_name();
+                                //let opr::Unit{..} = *unit;
+                                view! {
+                                    <tr
+                                         class:selected=move || {
+                                             matches!(selected_row_num.get(),
+                                                      Some(index) if index == i)
+                                         }
+                                         on:click=move |_| {
+                                             select_unit.set(Some(group.clone()));
+                                             set_selected_row_num.set(Some(i));
+                                    }>
+                                        <td> {group_name} </td>
+                                    </tr>
+                                }
+                            })
+                            .collect_view()
+                    }}
+                </tbody>
+            </table>
+        </table-wrapper>
+    }
+}
 
 // #[component]
 // fn RemoveArmyButton(army_id: String) -> impl IntoView {

--- a/src/main.rs
+++ b/src/main.rs
@@ -502,7 +502,7 @@ fn UnitDetails(unit: Rc<opr::Unit>,
             </thaw::Space>
         </p>
         <p><UnitUpgradesList loadout_list={loadout.clone()} /></p>
-//        <EquipmentList loadout_list={loadout.clone()} />
+        <EquipmentList loadout_list={loadout.clone()} />
     }
 }
 
@@ -532,29 +532,29 @@ fn UnitUpgradesList(loadout_list: Vec<Rc<opr::UnitLoadout>>) -> impl IntoView {
     }
 }
 
-// #[component]
-// fn EquipmentList(loadout_list: Vec<Rc<opr::UnitLoadout>>) -> impl IntoView {
-//     view! {
-//         <ltn::TableContainer>
-//             <ltn::Table bordered=true hoverable=true>
-//                 <ltn::TableBody>
-//                     {move || {
-//                         loadout_list
-//                             .clone()
-//                             .into_iter()
-//                             .filter(|loadout| matches!(**loadout, opr::UnitLoadout::Equipment{..}))
-//                             .map(|loadout| {
-//                                 view! {
-//                                     <EquipmentItem loadout />
-//                                 }
-//                             })
-//                             .collect_view()
-//                     }}
-//                 </ltn::TableBody>
-//             </ltn::Table>
-//         </ltn::TableContainer>
-//     }
-// }
+#[component]
+fn EquipmentList(loadout_list: Vec<Rc<opr::UnitLoadout>>) -> impl IntoView {
+    view! {
+        <table-wrapper>
+            <table bordered=true hoverable=true>
+                <tbody>
+                    {move || {
+                        loadout_list
+                            .clone()
+                            .into_iter()
+                            .filter(|loadout| matches!(**loadout, opr::UnitLoadout::Equipment{..}))
+                            .map(|loadout| {
+                                view! {
+//                                    <EquipmentItem loadout />
+                                }
+                            })
+                            .collect_view()
+                    }}
+                </tbody>
+            </table>
+        </table-wrapper>
+    }
+}
 
 // #[component]
 // fn EquipmentItem(loadout: Rc<opr::UnitLoadout>) -> impl IntoView {

--- a/src/main.rs
+++ b/src/main.rs
@@ -502,44 +502,44 @@ fn GroupDetails(group: Arc<opr::UnitGroup>,
             </thaw::Space>
         </h3>
 
-        // {
-        //     let single = group.units.len() == 1;
-        //     group.units.iter()
-        //         .map(|unit| view! {<UnitDetails unit=Arc::clone(unit) single />})
-        //         .collect_view()
-        // }
+        {
+            let single = group.units.len() == 1;
+            group.units.iter()
+                .map(|unit| view! {<UnitDetails unit=Arc::clone(unit) single />})
+                .collect_view()
+        }
 
         // <SpecialRulesDefList group=Arc::clone(&group) army />
     }
 }
 
-// #[component]
-// fn UnitDetails(unit: Arc<opr::Unit>,
-//                single: bool,
-// ) -> impl IntoView
-// {
-//     let unit_name = unit.formatted_name();
-//     let opr::Unit{quality, defense, full_cost, ref loadout, ref special_rules, ..} = *unit;
-//     let special_rules = special_rules.clone();
+#[component]
+fn UnitDetails(unit: Arc<opr::Unit>,
+               single: bool,
+) -> impl IntoView
+{
+    let unit_name = unit.formatted_name();
+    let opr::Unit{quality, defense, full_cost, ref loadout, ref special_rules, ..} = *unit;
+    let special_rules = special_rules.clone();
 
-//     view! {
-//         <p>
-//             <thaw::Space justify=thaw::SpaceJustify::SpaceBetween>
-//                 <span>
-//                     <span class="unit">
-//                         {(!single).then(|| format!("{unit_name}: "))}
-//                         {format!("Q{quality} D{defense}")}
-//                     </span>
-//                     " "
-//                     <SpecialRulesList special_rules={special_rules.clone()} />
-//                 </span>
-//                 {format!("{full_cost} pts")}
-//             </thaw::Space>
-//         </p>
-//         <p><UnitUpgradesList loadout_list={loadout.clone()} /></p>
-//         <EquipmentList loadout_list={loadout.clone()} />
-//     }
-// }
+    view! {
+        <p>
+            <thaw::Space justify=thaw::SpaceJustify::SpaceBetween>
+                <span>
+                    <span class="unit">
+                        {(!single).then(|| format!("{unit_name}: "))}
+                        {format!("Q{quality} D{defense}")}
+                    </span>
+                    " "
+                    // <SpecialRulesList special_rules={special_rules.clone()} />
+                </span>
+                {format!("{full_cost} pts")}
+            </thaw::Space>
+        </p>
+        // <p><UnitUpgradesList loadout_list={loadout.clone()} /></p>
+        // <EquipmentList loadout_list={loadout.clone()} />
+    }
+}
 
 // #[component]
 // fn UnitUpgradesList(loadout_list: Vec<Arc<opr::UnitLoadout>>) -> impl IntoView {

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,26 +23,27 @@ fn main() {
     mount_to_body(|| view! { <AppBoilerplate/> })
 }
 
-// #[derive(Clone)]
-// struct Army {
-//     army_id: Signal<String>,
-//     unit_selection: RwSignal<Option<Arc<opr::UnitGroup>>>,
-//     army_data: Resource<String, Result<Arc<opr::Army>, String>>,
-// }
+#[derive(Clone)]
+struct Army {
+    army_id: Signal<String>,
+    unit_selection: RwSignal<Option<Arc<opr::UnitGroup>>>,
+    //army_data: Resource<String, Result<Arc<opr::Army>, String>>,
+}
 
-// impl Army {
-//     fn new(army_id: Signal<String>) -> Army
-//     {
-//         let unit_selection = RwSignal::new(None::<Arc<opr::UnitGroup>>);
-//         let army_data = Resource::new(
-//             move || army_id.get(),
-//             |army_id_value| {
-//                 let url = opr::get_army_url(&army_id_value);
-//                 async move { load_json_from_url::<Arc<opr::Army>>(&url).await }
-//             });
-//         Army{army_id, unit_selection, army_data}
-//     }
-// }
+impl Army {
+    fn new(army_id: Signal<String>) -> Army
+    {
+        let unit_selection = RwSignal::new(None::<Arc<opr::UnitGroup>>);
+        //let army_data = Resource::new(
+        //    move || army_id.get(),
+        //    |army_id_value| {
+        //        let url = opr::get_army_url(&army_id_value);
+        //        async move { load_json_from_url::<Arc<opr::Army>>(&url).await }
+        //    });
+        Army{army_id, unit_selection//, army_data
+        }
+    }
+}
 
 async fn load_json_from_url<T>(url: &str) -> Result<T, String>
 where
@@ -247,46 +248,46 @@ fn ArmiesView(army_ids: Signal<Vec<String>>) -> impl IntoView {
                                             .enumerate().collect::<Vec<(usize, String)>>())
                  key=|k: &(usize, String)| k.clone()
                  children=move |(i, id)| view! {
-                     "Army" //<ArmyContainer army={Army::new(Signal::derive(move || id.clone()))}
-                            //       side={if i == 0 {thaw::DrawerPlacement::Left}
-                            //             else {thaw::DrawerPlacement::Right}} />
+                     <ArmyContainer army={Army::new(Signal::derive(move || id.clone()))}
+                                    side={if i == 0 {thaw::DrawerPosition::Left}
+                                          else {thaw::DrawerPosition::Right}} />
                  }
              />
         </thaw::Flex>
     }
 }
 
-// #[derive(Clone)]
-// struct DrawerControl {
-//     shown: RwSignal<bool>,
-// }
-// impl Default for DrawerControl {
-//     fn default() -> Self {
-//         DrawerControl {
-//             shown: create_rw_signal(false),
-//         }
-//     }
-// }
+#[derive(Clone)]
+struct DrawerControl {
+    shown: RwSignal<bool>,
+}
+impl Default for DrawerControl {
+    fn default() -> Self {
+        DrawerControl {
+            shown: RwSignal::new(false),
+        }
+    }
+}
 
-// /// A component container for the army list and the drawer, so they
-// /// can share a common context
-// #[component]
-// fn ArmyContainer(army: Army, side: thaw::DrawerPlacement) -> impl IntoView {
-//     // the `shown` status can be changed by eg. selecting in the army
-//     // list, or using close button in the drawer itself
-//     let drawer_control = DrawerControl::default();
-//     let shown = drawer_control.shown.clone();
-//     create_effect(move |_| {
-//         shown.set(army.unit_selection.with(Option::is_some));
-//     });
+/// A component container for the army list and the drawer, so they
+/// can share a common context
+#[component]
+fn ArmyContainer(army: Army, side: thaw::DrawerPosition) -> impl IntoView {
+    // the `shown` status can be changed by eg. selecting in the army
+    // list, or using close button in the drawer itself
+    let drawer_control = DrawerControl::default();
+    let shown = drawer_control.shown.clone();
+    Effect::new(move |_| {
+        shown.set(army.unit_selection.with(Option::is_some));
+    });
 
-//     view! {
-//         <Provider value=drawer_control >
-//             <DetailsDrawer side army=army.clone() />
-//             <ArmyList army />
-//         </Provider>
-//     }
-// }
+    view! {
+        <leptos::context::Provider value=drawer_control >
+            //<DetailsDrawer side army=army.clone() />
+            "Army" //<ArmyList army />
+        </leptos::context::Provider>
+    }
+}
 
 // #[component]
 // fn ArmyList(army: Army,

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,21 +27,20 @@ fn main() {
 struct Army {
     army_id: Signal<String>,
     unit_selection: RwSignal<Option<Arc<opr::UnitGroup>>>,
-    //army_data: Resource<String, Result<Arc<opr::Army>, String>>,
+    army_data: AsyncDerived<Result<Arc<opr::Army>, String>, LocalStorage>,
 }
 
 impl Army {
     fn new(army_id: Signal<String>) -> Army
     {
         let unit_selection = RwSignal::new(None::<Arc<opr::UnitGroup>>);
-        //let army_data = Resource::new(
-        //    move || army_id.get(),
-        //    |army_id_value| {
-        //        let url = opr::get_army_url(&army_id_value);
-        //        async move { load_json_from_url::<Arc<opr::Army>>(&url).await }
-        //    });
-        Army{army_id, unit_selection//, army_data
-        }
+        let army_data = AsyncDerived::new_unsync(
+            move || {
+                let army_id_value = army_id.get();
+                let url = opr::get_army_url(&army_id_value);
+                async move { load_json_from_url::<Arc<opr::Army>>(&url).await }
+            });
+        Army{army_id, unit_selection, army_data}
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,13 +159,13 @@ fn App() -> impl IntoView {
                         style="flex: 1">
                 <Show when=move || { army_ids.with(Result::is_ok) }
                       fallback=move || view! {
-                          // <SelectView alert_type={thaw::AlertVariant::Warning}
-                          //             message=army_ids.get().err().unwrap() />
+                          <SelectView alert_type={thaw::MessageBarIntent::Warning}
+                                      message=army_ids.get().err().unwrap() />
                       } >
                     <Show when=move || { ! army_ids.get().unwrap().is_empty() }
                           fallback=|| view! {
-                              // <SelectView alert_type={thaw::AlertVariant::Warning} // FIXME: Info
-                              //             message="no army selected".to_string() />
+                              <SelectView alert_type={thaw::MessageBarIntent::Info}
+                                          message="no army selected".to_string() />
                           } >
                         "Armies" // <ArmiesView army_ids=Signal::derive(move || army_ids.get().unwrap().clone()) />
                     </Show>
@@ -175,21 +175,23 @@ fn App() -> impl IntoView {
     }
 }
 
-// #[component]
-// fn SelectView(message: String, alert_type: thaw::AlertVariant) -> impl IntoView {
-//     // reset global game_system so a different can be enabled by new armies
-//     let app_game_system = expect_context::<RwSignal<Option<opr::GameSystem>>>();
-//     app_game_system.set(None);
+#[component]
+fn SelectView(message: String, alert_type: thaw::MessageBarIntent) -> impl IntoView {
+    // reset global game_system so a different can be enabled by new armies
+    let app_game_system = expect_context::<RwSignal<Option<opr::GameSystem>>>();
+    app_game_system.set(None);
 
-//     view! {
-//         <Title text="select armies"/>
-//         <thaw::Alert variant=alert_type>
-//             {message}
-//         </thaw::Alert>
+    view! {
+        <Title text="select armies"/>
+        <thaw::MessageBar intent=alert_type>
+            <thaw::MessageBarBody>
+                {message}
+            </thaw::MessageBarBody>
+        </thaw::MessageBar>
 
-//         <SampleMatchups/>
-//     }
-// }
+//        <SampleMatchups/>
+    }
+}
 
 // #[component]
 // fn SampleMatchups() -> impl IntoView {

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,54 +183,56 @@ fn SelectView(message: String, alert_type: thaw::MessageBarIntent) -> impl IntoV
 
     view! {
         <Title text="select armies"/>
-        <thaw::MessageBar intent=alert_type>
-            <thaw::MessageBarBody>
-                {message}
-            </thaw::MessageBarBody>
-        </thaw::MessageBar>
+        <thaw::Flex vertical=true class="sample-matchups">
+            <thaw::MessageBar intent=alert_type>
+                <thaw::MessageBarBody>
+                    {message}
+                </thaw::MessageBarBody>
+            </thaw::MessageBar>
 
-//        <SampleMatchups/>
+            <SampleMatchups/>
+        </thaw::Flex>
     }
 }
 
-// #[component]
-// fn SampleMatchups() -> impl IntoView {
-//     view! {
-//         <h3> "Notice" </h3>
-//         <p>
-//             "This app is a technical preview. "
-//             "Remember to use smartphones in landscape mode."
-//         </p>
-//         <h3> "Sample matchups" </h3>
-//         <table-wrapper>
-//             <thaw::Table> // FIXME: bordered=true hoverable=true>
-//                 <tbody>
-//                     <tr>
-//                         <td>
-//                             <em>"Grimdark Future — "</em>
-//                             <a href="./?armies=Rrlct39EGuct,p2KIbSBOYpSB">
-//                             "Robots Legion vs. Prime Brothers" </a>
-//                         </td>
-//                     </tr>
-//                     <tr>
-//                         <td>
-//                             <em>"Grimdark Future — "</em>
-//                             <a href="./?armies=Mlwpoh1AGLC2">
-//                             "Robots Legion (single list)" </a>
-//                         </td>
-//                     </tr>
-//                     <tr>
-//                         <td>
-//                             <em>"Age of Fantasy: Skirmish — "</em>
-//                             <a href="./?armies=zhz5uajqHdt5,ZTgIvcYABynP">
-//                             "War Disciples vs. Eternal Wardens" </a>
-//                         </td>
-//                     </tr>
-//                 </tbody>
-//             </thaw::Table>
-//         </table-wrapper>
-//     }
-// }
+#[component]
+fn SampleMatchups() -> impl IntoView {
+    view! {
+        <h3> "Notice" </h3>
+        <p>
+            "This app is a technical preview. "
+            "Remember to use smartphones in landscape mode."
+        </p>
+        <h3> "Sample matchups" </h3>
+        <table-wrapper>
+            <table> // FIXME: bordered=true hoverable=true>
+                <tbody>
+                    <tr>
+                        <td>
+                            <em>"Grimdark Future — "</em>
+                            <a href="./?armies=Rrlct39EGuct,p2KIbSBOYpSB">
+                            "Robots Legion vs. Prime Brothers" </a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <em>"Grimdark Future — "</em>
+                            <a href="./?armies=Mlwpoh1AGLC2">
+                            "Robots Legion (single list)" </a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <em>"Age of Fantasy: Skirmish — "</em>
+                            <a href="./?armies=zhz5uajqHdt5,ZTgIvcYABynP">
+                            "War Disciples vs. Eternal Wardens" </a>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </table-wrapper>
+    }
+}
 
 // /// the main view, showing multiple armies and providing detail
 // /// drawers for selections

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,11 +309,11 @@ fn ArmyList(army: Army,
                                         {message}
                                     </thaw::MessageBarBody>
                                 </thaw::MessageBar>
-                                // // FIXME: hack to have the button on errors have the same
-                                // // size as the one on titles
-                                // <span style="font-size: var(--typography-h2-font-size);">
-                                //     <RemoveArmyButton army_id />
-                                // </span>
+                                // FIXME: hack to have the button on errors have the same
+                                // size as the one on titles
+                                <span style="font-size: var(--typography-h2-font-size);">
+                                    <RemoveArmyButton army_id />
+                                </span>
                             </thaw::Flex>
                         })
                     },
@@ -353,7 +353,7 @@ fn ArmyList(army: Army,
                                 view! {
                                     <h2>
                                         <a target="_blank" href={af_url}>{name}</a>
-                                    // <RemoveArmyButton army_id />
+                                        <RemoveArmyButton army_id />
                                     </h2>
                                 }
                             }}
@@ -422,28 +422,28 @@ fn UnitsList(unit_groups: Vec<Arc<opr::UnitGroup>>,
     }
 }
 
-// #[component]
-// fn RemoveArmyButton(army_id: String) -> impl IntoView {
-//     let mut ids =
-//         use_context::<Signal<Vec<String>>>()
-//         .expect("should find army_ids in context")
-//         .get();
-//     ids.remove(ids.iter().position(|x| *x == army_id)
-//                .expect("id should be in the list to remove it"));
-//     let remove_army_url = if ids.is_empty() {
-//         "./".to_string()
-//     } else {
-//         format!("./?armies={}", ids.join(","))
-//     };
+#[component]
+fn RemoveArmyButton(army_id: String) -> impl IntoView {
+    let mut ids =
+        use_context::<Signal<Vec<String>>>()
+        .expect("should find army_ids in context")
+        .get();
+    ids.remove(ids.iter().position(|x| *x == army_id)
+               .expect("id should be in the list to remove it"));
+    let remove_army_url = if ids.is_empty() {
+        "./".to_string()
+    } else {
+        format!("./?armies={}", ids.join(","))
+    };
 
-//     view! {
-//         <a href=remove_army_url >
-//             <button class="rm_army">
-//                 <thaw::Icon icon=icondata::IoCloseCircleOutline />
-//             </button>
-//         </a>
-//     }
-// }
+    view! {
+        <a href=remove_army_url >
+            <button class="rm_army">
+                <thaw::Icon icon=icondata::IoCloseCircleOutline />
+            </button>
+        </a>
+    }
+}
 
 // #[component]
 // fn DetailsDrawer(army: Army,

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,46 +220,46 @@ fn ArmiesView(army_ids: Signal<Vec<String>>) -> impl IntoView {
                                             .enumerate().collect::<Vec<(usize, String)>>())
                  key=|k: &(usize, String)| k.clone()
                  children=move |(i, id)| view! {
-                     "Army" //<ArmyContainer army={Army::new(Signal::derive(move || id.clone()))}
-                            //        side={if i == 0 {ltn::DrawerSide::Left}
-                            //              else {ltn::DrawerSide::Right}} />
+                     <ArmyContainer army={Army::new(Signal::derive(move || id.clone()))}
+                                    side={if i == 0 {thaw::DrawerPlacement::Left}
+                                          else {thaw::DrawerPlacement::Right}} />
                  }
              />
         </thaw::Flex>
     }
 }
 
-// #[derive(Clone)]
-// struct DrawerControl {
-//     shown: RwSignal<bool>,
-// }
-// impl Default for DrawerControl {
-//     fn default() -> Self {
-//         DrawerControl {
-//             shown: create_rw_signal(false),
-//         }
-//     }
-// }
+#[derive(Clone)]
+struct DrawerControl {
+    shown: RwSignal<bool>,
+}
+impl Default for DrawerControl {
+    fn default() -> Self {
+        DrawerControl {
+            shown: create_rw_signal(false),
+        }
+    }
+}
 
-// /// A component container for the army list and the drawer, so they
-// /// can share a common context
-// #[component]
-// fn ArmyContainer(army: Army, side: ltn::DrawerSide) -> impl IntoView {
-//     // the `shown` status can be changed by eg. selecting in the army
-//     // list, or using close button in the drawer itself
-//     let drawer_control = DrawerControl::default();
-//     let shown = drawer_control.shown.clone();
-//     create_effect(move |_| {
-//         shown.set(army.unit_selection.with(Option::is_some));
-//     });
+/// A component container for the army list and the drawer, so they
+/// can share a common context
+#[component]
+fn ArmyContainer(army: Army, side: thaw::DrawerPlacement) -> impl IntoView {
+    // the `shown` status can be changed by eg. selecting in the army
+    // list, or using close button in the drawer itself
+    let drawer_control = DrawerControl::default();
+    let shown = drawer_control.shown.clone();
+    create_effect(move |_| {
+        shown.set(army.unit_selection.with(Option::is_some));
+    });
 
-//     view! {
-//         <Provider value=drawer_control >
-//             <DetailsDrawer side army=army.clone() />
-//             <ArmyList army />
-//         </Provider>
-//     }
-// }
+    view! {
+        <Provider value=drawer_control >
+            //<DetailsDrawer side army=army.clone() />
+            "Army" //<ArmyList army />
+        </Provider>
+    }
+}
 
 // #[component]
 // fn ArmyList(army: Army,

--- a/src/main.rs
+++ b/src/main.rs
@@ -331,8 +331,8 @@ fn ArmyList(army: Army,
                                 let check_inconsistency = check_inconsistency();
                                 if check_inconsistency.is_none() {
                                     view! {
-                                        // <UnitsList unit_groups={unit_groups.clone()}
-                                        //            select_unit=army.unit_selection />
+                                        <UnitsList unit_groups={unit_groups.clone()}
+                                                   select_unit=army.unit_selection />
                                     }.into_view()
                                 } else {
                                     view! {
@@ -351,46 +351,44 @@ fn ArmyList(army: Army,
     }
 }
 
-// #[component]
-// fn UnitsList(unit_groups: Vec<Rc<opr::UnitGroup>>,
-//              select_unit: RwSignal<Option<Rc<opr::UnitGroup>>>, // FIXME only need WriteSignal here
-// ) -> impl IntoView {
-//     let (selected_row_num, set_selected_row_num) = create_signal(None::<usize>);
-//     view! {
-//         <ltn::TableContainer>
-//             <ltn::Table bordered=true hoverable=true>
-//                 <ltn::TableBody>
-//                     {move || {
-//                         unit_groups
-//                             .clone()
-//                             .into_iter()
-//                             .enumerate()
-//                             .map(|(i, group)| {
-//                                 let group_name = (*group).formatted_name();
-//                                 //let opr::Unit{..} = *unit;
-//                                 view! {
-//                                     // FIXME this ought to be a ltn::TableRow, which does
-//                                     // not allow for dynamic classes or even for class
-//                                     <leptonic-table-row
-//                                          class:selected=move || {
-//                                              matches!(selected_row_num.get(),
-//                                                       Some(index) if index == i)
-//                                          }
-//                                          on:click=move |_| {
-//                                              select_unit.set(Some(group.clone()));
-//                                              set_selected_row_num.set(Some(i));
-//                                     }>
-//                                         <ltn::TableCell> {group_name} </ltn::TableCell>
-//                                     </leptonic-table-row>
-//                                 }
-//                             })
-//                             .collect_view()
-//                     }}
-//                 </ltn::TableBody>
-//             </ltn::Table>
-//         </ltn::TableContainer>
-//     }
-// }
+#[component]
+fn UnitsList(unit_groups: Vec<Rc<opr::UnitGroup>>,
+             select_unit: RwSignal<Option<Rc<opr::UnitGroup>>>, // FIXME only need WriteSignal here
+) -> impl IntoView {
+    let (selected_row_num, set_selected_row_num) = create_signal(None::<usize>);
+    view! {
+        <table-wrapper>
+            <table bordered=true hoverable=true>
+                <tbody>
+                    {move || {
+                        unit_groups
+                            .clone()
+                            .into_iter()
+                            .enumerate()
+                            .map(|(i, group)| {
+                                let group_name = (*group).formatted_name();
+                                //let opr::Unit{..} = *unit;
+                                view! {
+                                    <tr
+                                         class:selected=move || {
+                                             matches!(selected_row_num.get(),
+                                                      Some(index) if index == i)
+                                         }
+                                         on:click=move |_| {
+                                             select_unit.set(Some(group.clone()));
+                                             set_selected_row_num.set(Some(i));
+                                    }>
+                                        <td> {group_name} </td>
+                                    </tr>
+                                }
+                            })
+                            .collect_view()
+                    }}
+                </tbody>
+            </table>
+        </table-wrapper>
+    }
+}
 
 // #[component]
 // fn RemoveArmyButton(army_id: String) -> impl IntoView {

--- a/src/main.rs
+++ b/src/main.rs
@@ -461,57 +461,57 @@ fn DetailsDrawer(army: Army,
             // FIXME use DrawerHeader?
             <thaw::DrawerBody>
                 <Show when=move || shown.get() >
-                   "GroupDetails" // <GroupDetails army=army.clone() side
-                    //               group=army.unit_selection.get().unwrap() />
+                    <GroupDetails army=army.clone() side
+                                  group=army.unit_selection.get().unwrap() />
                 </Show>
             </thaw::DrawerBody>
         </thaw::OverlayDrawer>
     }
 }
 
-// #[component]
-// fn GroupDetails(group: Arc<opr::UnitGroup>,
-//                 army: Army,
-//                 side: thaw::DrawerPlacement,
-// ) -> impl IntoView
-// {
-//     let opr::UnitGroup{full_cost, ..} = *group;
-//     let shown = use_context::<DrawerControl>().unwrap().shown;
-//     let group_name = group.formatted_name();
-//     let close_button = |glyph| view! {
-//         <thaw::Button //color=ltn::ButtonColor::Secondary
-//                       on_click=move |_| shown.set(false)> {glyph} </thaw::Button>
-//     };
-//     let (left_button, right_button) = match side {
-//         thaw::DrawerPlacement::Left  => ( Some(close_button("<")), None ),
-//         thaw::DrawerPlacement::Right => ( None, Some(close_button(">")) ),
-//         _ => unreachable!(),
-//     };
+#[component]
+fn GroupDetails(group: Arc<opr::UnitGroup>,
+                army: Army,
+                side: thaw::DrawerPosition,
+) -> impl IntoView
+{
+    let opr::UnitGroup{full_cost, ..} = *group;
+    let shown = use_context::<DrawerControl>().unwrap().shown;
+    let group_name = group.formatted_name();
+    let close_button = |glyph| view! {
+        <thaw::Button //color=ltn::ButtonColor::Secondary
+                      on_click=move |_| shown.set(false)> {glyph} </thaw::Button>
+    };
+    let (left_button, right_button) = match side {
+        thaw::DrawerPosition::Left  => ( Some(close_button("<")), None ),
+        thaw::DrawerPosition::Right => ( None, Some(close_button(">")) ),
+        _ => unreachable!(),
+    };
 
-//     view! {
-//         <h3>
-//             <thaw::Space justify=thaw::SpaceJustify::SpaceBetween >
-//                 <thaw::Space>
-//                     {left_button}
-//                     {group_name}
-//                 </thaw::Space>
-//                 <thaw::Space>
-//                     {format!("{full_cost} pts")}
-//                     {right_button}
-//                 </thaw::Space>
-//             </thaw::Space>
-//         </h3>
+    view! {
+        <h3>
+            <thaw::Space justify=thaw::SpaceJustify::SpaceBetween >
+                <thaw::Space>
+                    {left_button}
+                    {group_name}
+                </thaw::Space>
+                <thaw::Space>
+                    {format!("{full_cost} pts")}
+                    {right_button}
+                </thaw::Space>
+            </thaw::Space>
+        </h3>
 
-//         {
-//             let single = group.units.len() == 1;
-//             group.units.iter()
-//                 .map(|unit| view! {<UnitDetails unit=Arc::clone(unit) single />})
-//                 .collect_view()
-//         }
+        // {
+        //     let single = group.units.len() == 1;
+        //     group.units.iter()
+        //         .map(|unit| view! {<UnitDetails unit=Arc::clone(unit) single />})
+        //         .collect_view()
+        // }
 
-//         <SpecialRulesDefList group=Arc::clone(&group) army />
-//     }
-// }
+        // <SpecialRulesDefList group=Arc::clone(&group) army />
+    }
+}
 
 // #[component]
 // fn UnitDetails(unit: Arc<opr::Unit>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,7 +144,7 @@ fn App() -> impl IntoView {
                               <SelectView alert_type={thaw::AlertVariant::Warning} // FIXME: Info
                                           message="no army selected".to_string() />
                           } >
-                        "Armies" // <ArmiesView army_ids=Signal::derive(move || army_ids.get().unwrap().clone()) />
+                        <ArmiesView army_ids=Signal::derive(move || army_ids.get().unwrap().clone()) />
                     </Show>
                 </Show>
             </thaw::Space>
@@ -207,29 +207,27 @@ fn SampleMatchups() -> impl IntoView {
     }
 }
 
-// /// the main view, showing multiple armies and providing detail
-// /// drawers for selections
-// #[component]
-// fn ArmiesView(army_ids: Signal<Vec<String>>) -> impl IntoView {
-//     provide_context(army_ids);
-//     view! {
-//         <Title text="view armies" />
-//         <ltn::Stack orientation=ltn::StackOrientation::Horizontal
-//                     spacing=ltn::Size::Em(1.0)
-//                     class="army_view" >
-//             <For each=move || army_ids.with(|ids| ids.iter()
-//                                             .map(String::clone)
-//                                             .enumerate().collect::<Vec<(usize, String)>>())
-//                  key=|k: &(usize, String)| k.clone()
-//                  children=move |(i, id)| view! {
-//                      <ArmyContainer army={Army::new(Signal::derive(move || id.clone()))}
-//                                     side={if i == 0 {ltn::DrawerSide::Left}
-//                                           else {ltn::DrawerSide::Right}} />
-//                  }
-//              />
-//         </ltn::Stack>
-//     }
-// }
+/// the main view, showing multiple armies and providing detail
+/// drawers for selections
+#[component]
+fn ArmiesView(army_ids: Signal<Vec<String>>) -> impl IntoView {
+    provide_context(army_ids);
+    view! {
+        <Title text="view armies" />
+        <thaw::Flex class="army_view" >
+            <For each=move || army_ids.with(|ids| ids.iter()
+                                            .map(String::clone)
+                                            .enumerate().collect::<Vec<(usize, String)>>())
+                 key=|k: &(usize, String)| k.clone()
+                 children=move |(i, id)| view! {
+                     "Army" //<ArmyContainer army={Army::new(Signal::derive(move || id.clone()))}
+                            //        side={if i == 0 {ltn::DrawerSide::Left}
+                            //              else {ltn::DrawerSide::Right}} />
+                 }
+             />
+        </thaw::Flex>
+    }
+}
 
 // #[derive(Clone)]
 // struct DrawerControl {

--- a/src/main.rs
+++ b/src/main.rs
@@ -536,36 +536,36 @@ fn UnitDetails(unit: Arc<opr::Unit>,
                 {format!("{full_cost} pts")}
             </thaw::Space>
         </p>
-        // <p><UnitUpgradesList loadout_list={loadout.clone()} /></p>
+        <p><UnitUpgradesList loadout_list={loadout.clone()} /></p>
         // <EquipmentList loadout_list={loadout.clone()} />
     }
 }
 
-// #[component]
-// fn UnitUpgradesList(loadout_list: Vec<Arc<opr::UnitLoadout>>) -> impl IntoView {
-//     view! {
-//         {move || {
-//             loadout_list
-//                 .clone()
-//                 .into_iter()
-//                 .filter(|loadout| matches!(**loadout, opr::UnitLoadout::Upgrade{..}))
-//                 .enumerate()
-//                 .map(|(i, loadout)| {
-//                     if let opr::UnitLoadout::Upgrade(ref upgrade) = *loadout {
-//                         let opr::UnitUpgrade{name, ref content, ..} = upgrade;
-//                         view! {
-//                             {move || if i > 0 { ", " } else { "" }}
-//                             {Arc::clone(name)} " (" <SpecialRulesList special_rules={content.clone()} />
-//                                 ")"
-//                         }
-//                     } else {
-//                         panic!();
-//                     }
-//                 })
-//                 .collect_view()
-//         }}
-//     }
-// }
+#[component]
+fn UnitUpgradesList(loadout_list: Vec<Arc<opr::UnitLoadout>>) -> impl IntoView {
+    view! {
+        {move || {
+            loadout_list
+                .clone()
+                .into_iter()
+                .filter(|loadout| matches!(**loadout, opr::UnitLoadout::Upgrade{..}))
+                .enumerate()
+                .map(|(i, loadout)| {
+                    if let opr::UnitLoadout::Upgrade(ref upgrade) = *loadout {
+                        let opr::UnitUpgrade{name, ref content, ..} = upgrade;
+                        view! {
+                            {move || if i > 0 { ", " } else { "" }}
+                            {Arc::clone(name)} " (" //<SpecialRulesList special_rules={content.clone()} />
+                                ")"
+                        }
+                    } else {
+                        panic!();
+                    }
+                })
+                .collect_view()
+        }}
+    }
+}
 
 // #[component]
 // fn EquipmentList(loadout_list: Vec<Arc<opr::UnitLoadout>>) -> impl IntoView {

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,48 +164,48 @@ fn SelectView(message: String, alert_type: thaw::AlertVariant) -> impl IntoView 
             {message}
         </thaw::Alert>
 
-        // <SampleMatchups/>
+        <SampleMatchups/>
     }
 }
 
-// #[component]
-// fn SampleMatchups() -> impl IntoView {
-//     view! {
-//         <h3> "Notice" </h3>
-//         <p>
-//             "This app is a technical preview. "
-//             "Remember to use smartphones in landscape mode."
-//         </p>
-//         <h3> "Sample matchups" </h3>
-//         <ltn::TableContainer>
-//             <ltn::Table bordered=true hoverable=true>
-//                 <ltn::TableBody>
-//                     <ltn::TableRow>
-//                         <ltn::TableCell>
-//                             <em>"Grimdark Future — "</em>
-//                             <a href="./?armies=Rrlct39EGuct,p2KIbSBOYpSB">
-//                             "Robots Legion vs. Prime Brothers" </a>
-//                         </ltn::TableCell>
-//                     </ltn::TableRow>
-//                     <ltn::TableRow>
-//                         <ltn::TableCell>
-//                             <em>"Grimdark Future — "</em>
-//                             <a href="./?armies=Mlwpoh1AGLC2">
-//                             "Robots Legion (single list)" </a>
-//                         </ltn::TableCell>
-//                     </ltn::TableRow>
-//                     <ltn::TableRow>
-//                         <ltn::TableCell>
-//                             <em>"Age of Fantasy: Skirmish — "</em>
-//                             <a href="./?armies=zhz5uajqHdt5,ZTgIvcYABynP">
-//                             "War Disciples vs. Eternal Wardens" </a>
-//                         </ltn::TableCell>
-//                     </ltn::TableRow>
-//                 </ltn::TableBody>
-//             </ltn::Table>
-//         </ltn::TableContainer>
-//     }
-// }
+#[component]
+fn SampleMatchups() -> impl IntoView {
+    view! {
+        <h3> "Notice" </h3>
+        <p>
+            "This app is a technical preview. "
+            "Remember to use smartphones in landscape mode."
+        </p>
+        <h3> "Sample matchups" </h3>
+        <table-wrapper>
+            <thaw::Table> // FIXME: bordered=true hoverable=true>
+                <tbody>
+                    <tr>
+                        <td>
+                            <em>"Grimdark Future — "</em>
+                            <a href="./?armies=Rrlct39EGuct,p2KIbSBOYpSB">
+                            "Robots Legion vs. Prime Brothers" </a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <em>"Grimdark Future — "</em>
+                            <a href="./?armies=Mlwpoh1AGLC2">
+                            "Robots Legion (single list)" </a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <em>"Age of Fantasy: Skirmish — "</em>
+                            <a href="./?armies=zhz5uajqHdt5,ZTgIvcYABynP">
+                            "War Disciples vs. Eternal Wardens" </a>
+                        </td>
+                    </tr>
+                </tbody>
+            </thaw::Table>
+        </table-wrapper>
+    }
+}
 
 // /// the main view, showing multiple armies and providing detail
 // /// drawers for selections

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,103 +256,100 @@ fn ArmyContainer(army: Army, side: thaw::DrawerPlacement) -> impl IntoView {
     view! {
         <Provider value=drawer_control >
             //<DetailsDrawer side army=army.clone() />
-            "Army" //<ArmyList army />
+            <ArmyList army />
         </Provider>
     }
 }
 
-// #[component]
-// fn ArmyList(army: Army,
-// ) -> impl IntoView {
-//     let app_game_system = expect_context::<RwSignal<Option<opr::GameSystem>>>();
-//     view! {
-//         <ltn::Stack spacing=ltn::Size::Em(0.5) class="army_list" >
-//         { move || {
-//             army.army_data.with(
-//                 |army_data| match army_data {
-//                     None => view! { <h2>"Loading..."</h2> }.into_view(),
-//                     Some(Err(message)) => {
-//                         let message = message.clone();
-//                         let army_id = army.army_id.get();
-//                         view! {
-//                             <ltn::Stack spacing=ltn::Size::Em(0.5)
-//                                         orientation=ltn::StackOrientation::Horizontal >
-//                                 <ltn::Alert variant=ltn::AlertVariant::Danger>
-//                                     <AlertContent slot>{message}</AlertContent>
-//                                 </ltn::Alert>
-//                                 // FIXME: hack to have the button on errors have the same
-//                                 // size as the one on titles
-//                                 <span style="font-size: var(--typography-h2-font-size);">
-//                                     <RemoveArmyButton army_id />
-//                                 </span>
-//                             </ltn::Stack>
-//                         }.into_view()
-//                     },
-//                     Some(Ok(army_data)) => {
-//                         let opr::Army{ref game_system, ref name, ref unit_groups, ..} = **army_data;
-//                         let game_system = game_system.clone();
-//                         let name = Rc::clone(name);
-//                         let unit_groups = unit_groups.clone();
+#[component]
+fn ArmyList(army: Army,
+) -> impl IntoView {
+    let app_game_system = expect_context::<RwSignal<Option<opr::GameSystem>>>();
+    view! {
+        <thaw::Space class="army_list" >
+        { move || {
+            army.army_data.with(
+                |army_data| match army_data {
+                    None => view! { <h2>"Loading..."</h2> }.into_view(),
+                    Some(Err(message)) => {
+                        let message = message.clone();
+                        let army_id = army.army_id.get();
+                        view! {
+                            <thaw::Space gap=thaw::SpaceGap::Small >
+                                <thaw::Alert variant=thaw::AlertVariant::Error>
+                                    {message}
+                                </thaw::Alert>
+                                // // FIXME: hack to have the button on errors have the same
+                                // // size as the one on titles
+                                // <span style="font-size: var(--typography-h2-font-size);">
+                                //     <RemoveArmyButton army_id />
+                                // </span>
+                            </thaw::Space>
+                        }.into_view()
+                    },
+                    Some(Ok(army_data)) => {
+                        let opr::Army{ref game_system, ref name, ref unit_groups, ..} = **army_data;
+                        let game_system = game_system.clone();
+                        let name = Rc::clone(name);
+                        let unit_groups = unit_groups.clone();
 
-//                         // since we are recreating an ArmyList, the Army must have changed
-//                         // (or this is an over-refresh bug), drawer is outdated so close it
-//                         let shown = use_context::<DrawerControl>().unwrap().shown;
-//                         shown.set(false);
+                        // since we are recreating an ArmyList, the Army must have changed
+                        // (or this is an over-refresh bug), drawer is outdated so close it
+                        let shown = use_context::<DrawerControl>().unwrap().shown;
+                        shown.set(false);
 
-//                         let check_inconsistency = move || {
-//                             match game_system.clone() {
-//                                 Err(e) => Some(e),
-//                                 Ok(game_system) => match app_game_system.get() {
-//                                     // not yet set: set it, ok
-//                                     None => {
-//                                         app_game_system.set(Some(game_system));
-//                                         None },
-//                                     // already set and matching this army: ok
-//                                     Some(app_game_system) if game_system == app_game_system
-//                                         => None,
-//                                     // already set and not matching: KO
-//                                     Some(_)
-//                                         => Some(format!("game system mismatch: {game_system}")),
-//                                 }
-//                             }
-//                         };
-//                         view! {
-//                             {move || {
-//                                 let name = Rc::clone(&name);
-//                                 let army_id = army.army_id.get();
-//                                 let af_url = format!("{}?id={army_id}", opr::ARMYFORGE_SHARE_URL);
-//                                 view! {
-//                                     <h2>
-//                                         <a target="_blank" href={af_url}>{name}</a>
-//                                         <RemoveArmyButton army_id />
-//                                     </h2>
-//                                 }
-//                             }}
-//                             {move || {
-//                                 let check_inconsistency = check_inconsistency();
-//                                 if check_inconsistency.is_none() {
-//                                     view! {
-//                                         <UnitsList unit_groups={unit_groups.clone()}
-//                                                    select_unit=army.unit_selection />
-//                                     }.into_view()
-//                                 } else {
-//                                     view! {
-//                                         <ltn::Alert variant=ltn::AlertVariant::Danger>
-//                                             <AlertContent slot>
-//                                                 {check_inconsistency.unwrap()}
-//                                             </AlertContent>
-//                                         </ltn::Alert>
-//                                     }.into_view()
-//                                 }
-//                             }}
-//                         }.into_view()
-//                     },
-//                 }
-//             )
-//         }}
-//         </ltn::Stack>
-//     }
-// }
+                        let check_inconsistency = move || {
+                            match game_system.clone() {
+                                Err(e) => Some(e),
+                                Ok(game_system) => match app_game_system.get() {
+                                    // not yet set: set it, ok
+                                    None => {
+                                        app_game_system.set(Some(game_system));
+                                        None },
+                                    // already set and matching this army: ok
+                                    Some(app_game_system) if game_system == app_game_system
+                                        => None,
+                                    // already set and not matching: KO
+                                    Some(_)
+                                        => Some(format!("game system mismatch: {game_system}")),
+                                }
+                            }
+                        };
+                        view! {
+                            {move || {
+                                let name = Rc::clone(&name);
+                                let army_id = army.army_id.get();
+                                let af_url = format!("{}?id={army_id}", opr::ARMYFORGE_SHARE_URL);
+                                view! {
+                                    <h2>
+                                        <a target="_blank" href={af_url}>{name}</a>
+                                        // <RemoveArmyButton army_id />
+                                    </h2>
+                                }
+                            }}
+                            {move || {
+                                let check_inconsistency = check_inconsistency();
+                                if check_inconsistency.is_none() {
+                                    view! {
+                                        // <UnitsList unit_groups={unit_groups.clone()}
+                                        //            select_unit=army.unit_selection />
+                                    }.into_view()
+                                } else {
+                                    view! {
+                                        <thaw::Alert variant=thaw::AlertVariant::Error>
+                                            {check_inconsistency.unwrap()}
+                                        </thaw::Alert>
+                                    }.into_view()
+                                }
+                            }}
+                        }.into_view()
+                    },
+                }
+            )
+        }}
+        </thaw::Space>
+    }
+}
 
 // #[component]
 // fn UnitsList(unit_groups: Vec<Rc<opr::UnitGroup>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,7 +255,7 @@ fn ArmyContainer(army: Army, side: thaw::DrawerPlacement) -> impl IntoView {
 
     view! {
         <Provider value=drawer_control >
-            //<DetailsDrawer side army=army.clone() />
+            <DetailsDrawer side army=army.clone() />
             <ArmyList army />
         </Provider>
     }
@@ -413,24 +413,26 @@ fn RemoveArmyButton(army_id: String) -> impl IntoView {
     }
 }
 
-// #[component]
-// fn DetailsDrawer(army: Army,
-//                  side: ltn::DrawerSide) -> impl IntoView {
-//     let pos_class = match side {
-//         ltn::DrawerSide::Left => "left",
-//         ltn::DrawerSide::Right => "right",
-//     };
+#[component]
+fn DetailsDrawer(army: Army,
+                 side: thaw::DrawerPlacement) -> impl IntoView {
+    let pos_class = match side {
+        thaw::DrawerPlacement::Left => "left",
+        thaw::DrawerPlacement::Right => "right",
+        _ => unreachable!(),
+    };
 
-//     let shown = use_context::<DrawerControl>().unwrap().shown;
-//     view! {
-//         <ltn::Drawer side shown class={format!("army_details {pos_class}")}>
-//             <Show when=move || shown.get() >
-//                 <GroupDetails army=army.clone() side
-//                               group=army.unit_selection.get().unwrap() />
-//             </Show>
-//         </ltn::Drawer>
-//     }
-// }
+    let shown = use_context::<DrawerControl>().unwrap().shown;
+    view! {
+        <thaw::Drawer placement=side show=shown modal_type=thaw::DrawerModalType::NonModal
+                      class={format!("army_details {pos_class} color-scheme--light")}>
+            <Show when=move || shown.get() >
+                "GroupDetails" // <GroupDetails army=army.clone() placement
+                //               group=army.unit_selection.get().unwrap() />
+            </Show>
+        </thaw::Drawer>
+    }
+}
 
 // #[component]
 // fn GroupDetails(group: Rc<opr::UnitGroup>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -545,7 +545,7 @@ fn EquipmentList(loadout_list: Vec<Rc<opr::UnitLoadout>>) -> impl IntoView {
                             .filter(|loadout| matches!(**loadout, opr::UnitLoadout::Equipment{..}))
                             .map(|loadout| {
                                 view! {
-//                                    <EquipmentItem loadout />
+                                    <EquipmentItem loadout />
                                 }
                             })
                             .collect_view()
@@ -556,36 +556,36 @@ fn EquipmentList(loadout_list: Vec<Rc<opr::UnitLoadout>>) -> impl IntoView {
     }
 }
 
-// #[component]
-// fn EquipmentItem(loadout: Rc<opr::UnitLoadout>) -> impl IntoView {
-//     if let opr::UnitLoadout::Equipment(ref equipment) = *loadout {
-//         let name = Rc::clone(&equipment.name);
-//         let special_rules = equipment.special_rules.clone();
-//         let opr::Equipment{count, range, attacks, ..} = *equipment;
-//         view! {
-//             <ltn::TableRow>
-//                 <ltn::TableCell>
-//                     {if count != 1
-//                         {format!("{}x ", count)} else {"".to_string()}}
-//                     {name}
-//                 </ltn::TableCell>
-//                 <ltn::TableCell>
-//                     {if range != 0
-//                         {format!(r#"{}""#, range )}
-//                         else {"-".to_string()}}
-//                 </ltn::TableCell>
-//                 <ltn::TableCell>
-//                     {format!("A{}", attacks)}
-//                 </ltn::TableCell>
-//                 <ltn::TableCell>
-//                     <SpecialRulesList special_rules={special_rules.clone()} />
-//                 </ltn::TableCell>
-//             </ltn::TableRow>
-//         }
-//     } else {
-//         panic!("EquipmentItem must be used on Equipment only");
-//     }
-// }
+#[component]
+fn EquipmentItem(loadout: Rc<opr::UnitLoadout>) -> impl IntoView {
+    if let opr::UnitLoadout::Equipment(ref equipment) = *loadout {
+        let name = Rc::clone(&equipment.name);
+        let special_rules = equipment.special_rules.clone();
+        let opr::Equipment{count, range, attacks, ..} = *equipment;
+        view! {
+            <tr>
+                <td>
+                    {if count != 1
+                        {format!("{}x ", count)} else {"".to_string()}}
+                    {name}
+                </td>
+                <td>
+                    {if range != 0
+                        {format!(r#"{}""#, range )}
+                        else {"-".to_string()}}
+                </td>
+                <td>
+                    {format!("A{}", attacks)}
+                </td>
+                <td>
+//                    <SpecialRulesList special_rules={special_rules.clone()} />
+                </td>
+            </tr>
+        }
+    } else {
+        panic!("EquipmentItem must be used on Equipment only");
+    }
+}
 
 // #[component]
 // fn SpecialRulesList(special_rules: Vec<Rc<opr::SpecialRule>>) -> impl IntoView {

--- a/src/main.rs
+++ b/src/main.rs
@@ -283,7 +283,7 @@ fn ArmyContainer(army: Army, side: thaw::DrawerPosition) -> impl IntoView {
 
     view! {
         <leptos::context::Provider value=drawer_control >
-            //<DetailsDrawer side army=army.clone() />
+            <DetailsDrawer side army=army.clone() />
             <ArmyList army />
         </leptos::context::Provider>
     }
@@ -445,26 +445,29 @@ fn RemoveArmyButton(army_id: String) -> impl IntoView {
     }
 }
 
-// #[component]
-// fn DetailsDrawer(army: Army,
-//                  side: thaw::DrawerPlacement) -> impl IntoView {
-//     let pos_class = match side {
-//         thaw::DrawerPlacement::Left => "left",
-//         thaw::DrawerPlacement::Right => "right",
-//         _ => unreachable!(),
-//     };
+#[component]
+fn DetailsDrawer(army: Army,
+                 side: thaw::DrawerPosition) -> impl IntoView {
+    let pos_class = match side {
+        thaw::DrawerPosition::Left => "left",
+        thaw::DrawerPosition::Right => "right",
+        _ => unreachable!(),
+    };
 
-//     let shown = use_context::<DrawerControl>().unwrap().shown;
-//     view! {
-//         <thaw::Drawer placement=side show=shown modal_type=thaw::DrawerModalType::NonModal
-//                       class={format!("army_details {pos_class} color-scheme--light")}>
-//             <Show when=move || shown.get() >
-//                 <GroupDetails army=army.clone() side
-//                               group=army.unit_selection.get().unwrap() />
-//             </Show>
-//         </thaw::Drawer>
-//     }
-// }
+    let shown = use_context::<DrawerControl>().unwrap().shown;
+    view! {
+        <thaw::OverlayDrawer position=side open=shown modal_type=thaw::DrawerModalType::NonModal
+                             class={format!("army_details {pos_class} color-scheme--light")}>
+            // FIXME use DrawerHeader?
+            <thaw::DrawerBody>
+                <Show when=move || shown.get() >
+                   "GroupDetails" // <GroupDetails army=army.clone() side
+                    //               group=army.unit_selection.get().unwrap() />
+                </Show>
+            </thaw::DrawerBody>
+        </thaw::OverlayDrawer>
+    }
+}
 
 // #[component]
 // fn GroupDetails(group: Arc<opr::UnitGroup>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -496,7 +496,7 @@ fn UnitDetails(unit: Rc<opr::Unit>,
                         {format!("Q{quality} D{defense}")}
                     </span>
                     " "
-//                    <SpecialRulesList special_rules={special_rules.clone()} />
+                    <SpecialRulesList special_rules={special_rules.clone()} />
                 </span>
                 {format!("{full_cost} pts")}
             </thaw::Space>
@@ -520,7 +520,7 @@ fn UnitUpgradesList(loadout_list: Vec<Rc<opr::UnitLoadout>>) -> impl IntoView {
                         let opr::UnitUpgrade{name, ref content, ..} = upgrade;
                         view! {
                             {move || if i > 0 { ", " } else { "" }}
-                            {Rc::clone(name)} " (" // <SpecialRulesList special_rules={content.clone()} />
+                            {Rc::clone(name)} " (" <SpecialRulesList special_rules={content.clone()} />
                                 ")"
                         }
                     } else {
@@ -578,7 +578,7 @@ fn EquipmentItem(loadout: Rc<opr::UnitLoadout>) -> impl IntoView {
                     {format!("A{}", attacks)}
                 </td>
                 <td>
-//                    <SpecialRulesList special_rules={special_rules.clone()} />
+                    <SpecialRulesList special_rules={special_rules.clone()} />
                 </td>
             </tr>
         }
@@ -587,27 +587,27 @@ fn EquipmentItem(loadout: Rc<opr::UnitLoadout>) -> impl IntoView {
     }
 }
 
-// #[component]
-// fn SpecialRulesList(special_rules: Vec<Rc<opr::SpecialRule>>) -> impl IntoView {
-//     special_rules.iter()
-//     // render each rule
-//         .enumerate()
-//         .map(|(i, special_rule)| {
-//             let separator = if i == 0 { "" } else { ", " };
-//             let rating = match special_rule.rating {
-//                 None => { "".to_string() },
-//                 Some(rating) => { format!("({})", rating) },
-//             };
-//             view! {
-//                 {separator}
-//                 <special-rule>
-//                     {Rc::clone(&special_rule.name)}
-//                 </special-rule>
-//                 {rating}
-//             }
-//         })
-//         .collect_view()
-// }
+#[component]
+fn SpecialRulesList(special_rules: Vec<Rc<opr::SpecialRule>>) -> impl IntoView {
+    special_rules.iter()
+    // render each rule
+        .enumerate()
+        .map(|(i, special_rule)| {
+            let separator = if i == 0 { "" } else { ", " };
+            let rating = match special_rule.rating {
+                None => { "".to_string() },
+                Some(rating) => { format!("({})", rating) },
+            };
+            view! {
+                {separator}
+                <special-rule>
+                    {Rc::clone(&special_rule.name)}
+                </special-rule>
+                {rating}
+            }
+        })
+        .collect_view()
+}
 
 // #[component]
 // fn SpecialRulesDefList(group: Rc<opr::UnitGroup>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,82 +72,85 @@ fn AppBoilerplate() -> impl IntoView {
                 "route not matched."
             </thaw::Alert>
         }.into_view() >
-            "There will be an app." //<App/>
+            <App/>
         </ltr::Router>
 // </ltn::Box>
     }
 }
 
-// #[derive(Params,PartialEq)]
-// struct UrlQuery {
-//     armies: Option<String>,
-// }
+#[derive(Params,PartialEq)]
+struct UrlQuery {
+    armies: Option<String>,
+}
 
-// /// the main application component
-// #[component]
-// fn App() -> impl IntoView {
-//     let query = ltr::use_query::<UrlQuery>();
-//     let game_system = create_rw_signal(None::<opr::GameSystem>);
-//     provide_context(game_system);
+/// the main application component
+#[component]
+fn App() -> impl IntoView {
+    let query = ltr::use_query::<UrlQuery>();
+    let game_system = create_rw_signal(None::<opr::GameSystem>);
+    provide_context(game_system);
 
-//     let common_rules: Resource<Option<opr::GameSystem>,
-//                                Result<Rc<opr::CommonRules>, String>> =
-//         create_resource(
-//             move || game_system.get(),
-//             |game_system| async move {
-//                 match game_system {
-//                     Some(game_system) => {
-//                         let url = opr::get_common_rules_url(game_system);
-//                         load_json_from_url(&url).await
-//                     },
-//                     None => Err("no common-rules, game system not known yet".to_string()),
-//                 }
-//             });
-//     provide_context(common_rules);
+    let common_rules: Resource<Option<opr::GameSystem>,
+                               Result<Rc<opr::CommonRules>, String>> =
+        create_resource(
+            move || game_system.get(),
+            |game_system| async move {
+                match game_system {
+                    Some(game_system) => {
+                        let url = opr::get_common_rules_url(game_system);
+                        load_json_from_url(&url).await
+                    },
+                    None => Err("no common-rules, game system not known yet".to_string()),
+                }
+            });
+    provide_context(common_rules);
 
-//     let army_ids = Signal::derive(move || {
-//         query.with(|params| {
-//             match params.as_ref().map(|params| params.armies.clone()) {
-//                 Ok(None) => Ok(vec!()),
-//                 Err(err) => Err(err.to_string()),
-//                 Ok(Some(armies_string)) => {
-//                     let v = armies_string
-//                         .split(',')
-//                         .map(|s| s.to_string())
-//                         .collect::<Vec<String>>();
-//                     Ok(v)
-//                 },
-//             }
-//         })
-//     });
-//     view! {
-//         <ltn::AppBar>
-//             <h1>
-//                 {APP_NAME}
-//                 {move || match game_system.get() {
-//                     Some(game_system) => format!(" - {game_system}"),
-//                     None => "".to_string(),
-//                 }}
-//             </h1>
-//             <ltn::ThemeToggle off=ltn::LeptonicTheme::Light on=ltn::LeptonicTheme::Dark/>
-//         </ltn::AppBar>
-//         <ltn::Box style="padding: 0 1em 1em 1em;">
-//             <Show when=move || { army_ids.with(Result::is_ok) }
-//                   fallback=move || view! {
-//                       <SelectView alert_type={ltn::AlertVariant::Warn}
-//                                   message=army_ids.get().err().unwrap() />
-//                   } >
-//                 <Show when=move || { ! army_ids.get().unwrap().is_empty() }
-//                       fallback=|| view! {
-//                           <SelectView alert_type={ltn::AlertVariant::Info}
-//                                       message="no army selected".to_string() />
-//                       } >
-//                     <ArmiesView army_ids=Signal::derive(move || army_ids.get().unwrap().clone()) />
-//                 </Show>
-//             </Show>
-//         </ltn::Box>
-//     }
-// }
+    let army_ids = Signal::derive(move || {
+        query.with(|params| {
+            match params.as_ref().map(|params| params.armies.clone()) {
+                Ok(None) => Ok(vec!()),
+                Err(err) => Err(err.to_string()),
+                Ok(Some(armies_string)) => {
+                    let v = armies_string
+                        .split(',')
+                        .map(|s| s.to_string())
+                        .collect::<Vec<String>>();
+                    Ok(v)
+                },
+            }
+        })
+    });
+    view! {
+        <thaw::Layout class="app color-scheme--light">
+            <thaw::LayoutHeader class="app-bar">
+                <thaw::Flex justify=thaw::FlexJustify::SpaceBetween align=thaw::FlexAlign::Center>
+                    <h1>
+                        {APP_NAME}
+                        {move || match game_system.get() {
+                            Some(game_system) => format!(" - {game_system}"),
+                            None => "".to_string(),
+                        }}
+                    </h1>
+                </thaw::Flex>
+            </thaw::LayoutHeader>
+            <thaw::Space class="app-contents" justify=thaw::SpaceJustify::Center>
+                <Show when=move || { army_ids.with(Result::is_ok) }
+                      fallback=move || view! {
+                          // <SelectView alert_type={ltn::AlertVariant::Warn}
+                          //             message=army_ids.get().err().unwrap() />
+                      } >
+                    <Show when=move || { ! army_ids.get().unwrap().is_empty() }
+                          fallback=|| view! {
+                              // <SelectView alert_type={ltn::AlertVariant::Info}
+                              //             message="no army selected".to_string() />
+                          } >
+                        "Armies" // <ArmiesView army_ids=Signal::derive(move || army_ids.get().unwrap().clone()) />
+                    </Show>
+                </Show>
+            </thaw::Space>
+        </thaw::Layout>
+    }
+}
 
 // #[component]
 // fn SelectView(message: String, alert_type: ltn::AlertVariant) -> impl IntoView {

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,11 +279,11 @@ fn ArmyList(army: Army,
                                 <thaw::Alert variant=thaw::AlertVariant::Error>
                                     {message}
                                 </thaw::Alert>
-                                // // FIXME: hack to have the button on errors have the same
-                                // // size as the one on titles
-                                // <span style="font-size: var(--typography-h2-font-size);">
-                                //     <RemoveArmyButton army_id />
-                                // </span>
+                                // FIXME: hack to have the button on errors have the same
+                                // size as the one on titles
+                                <span style="font-size: var(--typography-h2-font-size);">
+                                    <RemoveArmyButton army_id />
+                                </span>
                             </thaw::Space>
                         }.into_view()
                     },
@@ -323,7 +323,7 @@ fn ArmyList(army: Army,
                                 view! {
                                     <h2>
                                         <a target="_blank" href={af_url}>{name}</a>
-                                        // <RemoveArmyButton army_id />
+                                        <RemoveArmyButton army_id />
                                     </h2>
                                 }
                             }}
@@ -390,28 +390,28 @@ fn UnitsList(unit_groups: Vec<Rc<opr::UnitGroup>>,
     }
 }
 
-// #[component]
-// fn RemoveArmyButton(army_id: String) -> impl IntoView {
-//     let mut ids =
-//         use_context::<Signal<Vec<String>>>()
-//         .expect("should find army_ids in context")
-//         .get();
-//     ids.remove(ids.iter().position(|x| *x == army_id)
-//                .expect("id should be in the list to remove it"));
-//     let remove_army_url = if ids.is_empty() {
-//         "./".to_string()
-//     } else {
-//         format!("./?armies={}", ids.join(","))
-//     };
+#[component]
+fn RemoveArmyButton(army_id: String) -> impl IntoView {
+    let mut ids =
+        use_context::<Signal<Vec<String>>>()
+        .expect("should find army_ids in context")
+        .get();
+    ids.remove(ids.iter().position(|x| *x == army_id)
+               .expect("id should be in the list to remove it"));
+    let remove_army_url = if ids.is_empty() {
+        "./".to_string()
+    } else {
+        format!("./?armies={}", ids.join(","))
+    };
 
-//     view! {
-//         <a href=remove_army_url >
-//             <button class="rm_army">
-//                 <ltn::Icon icon=ltn::icondata::IoCloseCircleOutline />
-//             </button>
-//         </a>
-//     }
-// }
+    view! {
+        <a href=remove_army_url >
+            <button class="rm_army">
+                <thaw::Icon icon=icondata::IoCloseCircleOutline />
+            </button>
+        </a>
+    }
+}
 
 // #[component]
 // fn DetailsDrawer(army: Army,

--- a/style/main.scss
+++ b/style/main.scss
@@ -2,20 +2,22 @@
     font-family: Roboto, sans-serif;
 }
 
-@import "./leptonic/leptonic-themes";
-
-[data-theme="light"] {
+.color-scheme--light {
     --brand-color: #3267ad;
-    --typography-p-margin: 0.1em 0 0.1em 0 ;
-    --typography-h3-margin: 0.5em 0 0.5em 0 ;
+    --app-background-color: #efebe8;
+    --table-wrapper-box-shadow-color: #666666;
+    --table-background-color: white;
     --table-background-color-selected: color-mix(in srgb, white 70%, var(--brand-color));
+    --drawer-background-color: #f9f7f6;
 }
 
-[data-theme="dark"] {
+.color-scheme--dark {
     --brand-color: #3267ad;
-    --typography-p-margin: 0.1em 0 0.1em 0 ;
-    --typography-h3-margin: 0.5em 0 0.5em 0 ;
+    --app-background-color: #1e1c1c;
+    --table-wrapper-box-shadow-color: #101010;
+    --table-background-color: #202020;
     --table-background-color-selected: color-mix(in srgb, black 70%, var(--brand-color));
+    --drawer-background-color: #323232;
 }
 
 html {
@@ -31,6 +33,9 @@ leptonic-app-bar {
     background: var(--brand-color);
     color: white;
     padding: 0 1em;
+    h1 {
+        margin: 0;
+    }
 }
 
 .army_view {

--- a/style/main.scss
+++ b/style/main.scss
@@ -1,7 +1,3 @@
-* {
-    font-family: Roboto, sans-serif;
-}
-
 .color-scheme--light {
     --brand-color: #3267ad;
     --app-background-color: #efebe8;

--- a/style/main.scss
+++ b/style/main.scss
@@ -36,6 +36,10 @@ body {
     padding: 0;
 }
 
+p {
+    margin: 0.1em 0 0.1em 0;
+}
+
 .app {
     min-height: 100vh;
 }
@@ -45,6 +49,7 @@ body {
     color: white;
     padding: 0 1em;
     h1 {
+        font-size: x-large;
         margin: 0;
     }
 }
@@ -90,6 +95,10 @@ table-wrapper {
 
     .army_list {
         h2 {
+            margin: 0.5em 0 0.2em 0;
+            display: flex;
+            justify-content: space-between;
+
             a {
                 &:link, &:visited {
                     color: var(--box-color);
@@ -123,9 +132,13 @@ table-wrapper {
 
         h3 {
             margin: 0 0 0.2em 0;
-            button div.name {
-                padding: 0.2em 0.5em;
+            button {
+                min-width: 0;
+                div.name {
+                    padding: 0.2em 0.5em;
+                }
             }
+            .thaw-space__item { align-self: center; }
         }
 
         span.unit {
@@ -141,9 +154,10 @@ table-wrapper {
             background-color: color-mix(in srgb,
                                         var(--table-background-color),
                                         rgb(100% 100%  100% / 20%));
+            line-height: 1.35;
             td {
                 text-align: center;
-                padding: 0.1em;
+                padding: 0;
             }
             // FIXME use more explicit qualifier than child number
             td:nth-child(2),

--- a/style/main.scss
+++ b/style/main.scss
@@ -8,6 +8,7 @@
     --table-wrapper-box-shadow-color: #666666;
     --table-background-color: white;
     --table-background-color-selected: color-mix(in srgb, white 70%, var(--brand-color));
+    --table-border-color: #e0e0e0;
     --drawer-background-color: #f9f7f6;
 }
 
@@ -17,6 +18,7 @@
     --table-wrapper-box-shadow-color: #101010;
     --table-background-color: #202020;
     --table-background-color-selected: color-mix(in srgb, black 70%, var(--brand-color));
+    --table-border-color: #4c4c4c;
     --drawer-background-color: #323232;
 }
 
@@ -60,6 +62,18 @@ table-wrapper {
     border-radius: 0.5em;
     // FIXME: shadow is cropped horizontally
     box-shadow: -2px 3px 15px -6px var(--table-wrapper-box-shadow-color);
+
+    table {
+        background-color: var(--table-background-color);
+        width: 100%;
+        line-height: 2;
+
+        border-collapse: collapse;
+        td {
+            border-bottom: 0.05em solid var(--table-border-color);
+            padding: 0.75em 1em;
+        }
+    }
 }
 
 .army_view {
@@ -138,7 +152,7 @@ specialrules-def-list {
     overflow-y: scroll;
 }
 
-leptonic-table-row.selected {
+tr.selected {
     background-color: var(--table-background-color-selected);
 }
 

--- a/style/main.scss
+++ b/style/main.scss
@@ -154,6 +154,10 @@ table-wrapper {
 
 specialrules-def-list {
     overflow-y: scroll;
+
+    p {
+        margin: 0.1em 0 0.1em 0;
+    }
 }
 
 tr.selected {

--- a/style/main.scss
+++ b/style/main.scss
@@ -108,10 +108,6 @@ table-wrapper {
 }
 
 .army_details.thaw-overlay-drawer {
-    .thaw-drawer-body {
-        padding: 0;
-    }
-
     padding: 0.2em;
     position: fixed;
     top: 0;
@@ -122,42 +118,46 @@ table-wrapper {
     width: 40%;
     max-height: calc(100vh - 1px);
 
-    h3 {
-        margin: 0 0 0.2em 0;
-        button div.name {
-            padding: 0.2em 0.5em;
+    .thaw-drawer-body {
+        padding: 0;
+
+        h3 {
+            margin: 0 0 0.2em 0;
+            button div.name {
+                padding: 0.2em 0.5em;
+            }
         }
-    }
 
-    span.unit {
-        font-weight: bold;
-    }
-
-    leptonic-table-container {
-        // FIXME: not ideal but how to do better?  Should be sufficient anyway
-        flex-shrink: 0;
-    }
-
-    leptonic-table {
-        background-color: color-mix(in srgb,
-                                    var(--table-background-color),
-                                    rgb(100% 100%  100% / 20%));
-        leptonic-table-cell {
-            text-align: center;
-            padding: 0.1em;
+        span.unit {
+            font-weight: bold;
         }
-        // FIXME use more explicit qualifier than child number
-        leptonic-table-cell:nth-child(2),
-        leptonic-table-cell:nth-child(3) {
-            width: 2em;
-        }
-    }
 
-    &.thaw-overlay-drawer--position-right {
-        right: 0;
-    }
-    &.thaw-overlay-drawer--position-left {
-        left: 0;
+        leptonic-table-container {
+            // FIXME: not ideal but how to do better?  Should be sufficient anyway
+            flex-shrink: 0;
+        }
+
+        leptonic-table {
+            background-color: color-mix(in srgb,
+                                        var(--table-background-color),
+                                        rgb(100% 100%  100% / 20%));
+            leptonic-table-cell {
+                text-align: center;
+                padding: 0.1em;
+            }
+            // FIXME use more explicit qualifier than child number
+            leptonic-table-cell:nth-child(2),
+            leptonic-table-cell:nth-child(3) {
+                width: 2em;
+            }
+        }
+
+        &.thaw-overlay-drawer--position-right {
+            right: 0;
+        }
+        &.thaw-overlay-drawer--position-left {
+            left: 0;
+        }
     }
 }
 

--- a/style/main.scss
+++ b/style/main.scss
@@ -98,7 +98,11 @@ table-wrapper {
     }
 }
 
-leptonic-drawer.army_details {
+.thaw-drawer.army_details {
+    .thaw-card {
+        background-color: transparent;
+    }
+
     padding: 0.2em;
     position: fixed;
     top: 0;

--- a/style/main.scss
+++ b/style/main.scss
@@ -107,7 +107,7 @@ table-wrapper {
     }
 }
 
-.army_details .thaw-overlay-drawer {
+.army_details.thaw-overlay-drawer {
     .thaw-drawer-body {
         padding: 0;
     }

--- a/style/main.scss
+++ b/style/main.scss
@@ -107,9 +107,9 @@ table-wrapper {
     }
 }
 
-.thaw-drawer.army_details {
-    .thaw-card {
-        background-color: transparent;
+.army_details .thaw-overlay-drawer {
+    .thaw-drawer-body {
+        padding: 0;
     }
 
     padding: 0.2em;
@@ -153,10 +153,10 @@ table-wrapper {
         }
     }
 
-    &.right {
+    &.thaw-overlay-drawer--position-right {
         right: 0;
     }
-    &.left {
+    &.thaw-overlay-drawer--position-left {
         left: 0;
     }
 }

--- a/style/main.scss
+++ b/style/main.scss
@@ -55,8 +55,12 @@ body {
     padding: 0 1em 1em 1em;
 }
 
-h3 {
-    margin: 0.5em 0 0.5em 0;
+.sample-matchups {
+    width: 100%;
+
+    h3 {
+        margin: 0.5em 0 0.5em 0;
+    }
 }
 
 table-wrapper {

--- a/style/main.scss
+++ b/style/main.scss
@@ -48,6 +48,20 @@ body {
     padding: 0 1em 1em 1em;
 }
 
+h3 {
+    margin: 0.5em 0 0.5em 0;
+}
+
+table-wrapper {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    transition: height 0.5s ease;
+    border-radius: 0.5em;
+    // FIXME: shadow is cropped horizontally
+    box-shadow: -2px 3px 15px -6px var(--table-wrapper-box-shadow-color);
+}
+
 .army_view {
     align-items: flex-start;
 

--- a/style/main.scss
+++ b/style/main.scss
@@ -1,3 +1,7 @@
+.thaw-config-provider {
+    font-size: 12px;
+}
+
 .color-scheme--light {
     --brand-color: #3267ad;
     --app-background-color: #efebe8;
@@ -25,10 +29,6 @@
     --table-background-color-selected: color-mix(in srgb, black 70%, var(--brand-color));
     --table-border-color: #4c4c4c;
     --drawer-background-color: #323232;
-}
-
-html {
-    font-size: 12px;
 }
 
 body {
@@ -132,22 +132,22 @@ table-wrapper {
             font-weight: bold;
         }
 
-        leptonic-table-container {
+        table-wrapper {
             // FIXME: not ideal but how to do better?  Should be sufficient anyway
             flex-shrink: 0;
         }
 
-        leptonic-table {
+        table {
             background-color: color-mix(in srgb,
                                         var(--table-background-color),
                                         rgb(100% 100%  100% / 20%));
-            leptonic-table-cell {
+            td {
                 text-align: center;
                 padding: 0.1em;
             }
             // FIXME use more explicit qualifier than child number
-            leptonic-table-cell:nth-child(2),
-            leptonic-table-cell:nth-child(3) {
+            td:nth-child(2),
+            td:nth-child(3) {
                 width: 2em;
             }
         }

--- a/style/main.scss
+++ b/style/main.scss
@@ -29,13 +29,23 @@ body {
     padding: 0;
 }
 
-leptonic-app-bar {
+.app {
+    min-height: 100vh;
+}
+
+.app-bar {
     background: var(--brand-color);
     color: white;
     padding: 0 1em;
     h1 {
         margin: 0;
     }
+}
+
+.app-contents {
+    background-color: var(--app-background-color);
+    height: fit-content;
+    padding: 0 1em 1em 1em;
 }
 
 .army_view {

--- a/style/main.scss
+++ b/style/main.scss
@@ -6,6 +6,15 @@
     --table-background-color-selected: color-mix(in srgb, white 70%, var(--brand-color));
     --table-border-color: #e0e0e0;
     --drawer-background-color: #f9f7f6;
+
+    .thaw-switch__input:enabled:not(:checked) ~ .thaw-switch__indicator {
+        color: white;
+
+        // mimic dark theme, so only `color` changes
+        --colorCompoundBrandBackground: #479ef5;
+        background-color: var(--colorCompoundBrandBackground);
+        border-color: var(--colorTransparentStroke);
+    }
 }
 
 .color-scheme--dark {

--- a/style/main.scss
+++ b/style/main.scss
@@ -80,7 +80,7 @@ table-wrapper {
         border-collapse: collapse;
         td {
             border-bottom: 0.05em solid var(--table-border-color);
-            padding: 0.75em 1em;
+            padding: 0.2em 1em;
         }
     }
 }


### PR DESCRIPTION
Leptonic is dead, and the more I play with Thaw the more I realize Leptonic's shortcomings...

Commits in this PR should all build and provide successive implementation of each component, by progressively reactivating them.

A first step switches to Thaw 0.3 while staying with Leptos 0.6 to avoid doing 2 simultaneous migrations, but various limitations in 0.3 make that conversion quite imperfect.  A second step switches to Thaw 0.4 and Leptos 0.7 (even though they are unreleased, they achieve a much better job).